### PR TITLE
Implement slide-out admin dashboard panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,247 @@
+# Midnight Store
+
+This project provides a lightweight PHP storefront and admin panel. Below is the directory layout used throughout the application.
+
+```
+/index.php                      - Main storefront entry point
+/config.php                     - Constants, DB config, paths
+/functions.php                  - Global helper functions
+/db.php                         - DB connection (PDO)
+/routes.php                     - Simple router
+/.htaccess                      - Clean URLs for Apache
+/robots.txt                     - Basic robots file
+/sitemap.xml                    - Sitemap placeholder
+
+/themes/
+  /default/
+    /layouts/
+      theme.php                 - Wrapper for all pages
+      password.php              - Password-protected layout
+      (visit /password to unlock store)
+    /templates/
+      index.json                - Homepage layout
+      product.json              - Product page
+      collection.json           - Collection page
+      cart.php                  - Cart page
+      search.json               - Search results
+      404.php                   - Not found page
+      blog.json                 - Blog index
+      article.json              - Blog post
+      gift_card.php             - Gift card view
+      page.about-us.json
+      page.contact.json
+      /customers/
+        login.php
+        register.php
+        account.php
+        orders.php
+        reset_password.php
+        addresses.php
+    /sections/
+      announcement-bar.php
+      header.php
+      footer.php
+      hero-banner.php
+      slideshow.php
+      image-with-text.php
+      product-grid.php
+      collection-list.php
+      testimonial-slider.php
+      newsletter.php
+      countdown.php
+      featured-product.php
+      video-banner.php
+      blog-posts.php
+      contact-form.php
+      faq-section.php
+      cart-items.php
+      search-results.php
+    /snippets/
+      product-card.php
+      price.php
+      compare-price.php
+      rating-stars.php
+      quantity-selector.php
+      swatch.php
+      breadcrumbs.php
+      pickup-availability.php
+      form-input.php
+      social-icons.php
+      icon.php
+      button.php
+    /assets/
+      theme.css
+      theme.js
+      custom.js
+      grid.css
+      reset.css
+      /components/
+        buttons.css
+        forms.css
+      /images/
+        logo.png
+        placeholder.png
+        hero.jpg
+        favicon.ico
+      /fonts/
+        montserrat.woff2
+      /icons/
+        sprite.svg
+    /config/
+      settings_schema.json
+      settings_data.json
+    /locales/
+      en.json
+      hi.json
+      fr.json
+
+/admin/
+  index.php
+Page layouts are stored in `themes/default/templates/*.json`. Each page uses a structured layout object with unique section IDs. Section settings are saved in `themes/default/config/layout_<page>.json`.
+  dashboard.php
+  products.php
+  collections.php
+  orders.php
+  customers.php
+  pages.php
+  blogs.php
+  discounts.php
+  settings.php
+  reports.php
+  theme-editor.php
+  themes.php
+  /assets/
+    admin.css
+    admin.js
+    theme-editor.css
+    theme-editor.js
+  /components/
+    nav.php
+    header.php
+    footer.php
+  /modals/
+    modal-product.php
+    modal-collection.php
+    modal-discount.php
+
+/backend/
+  /auth/
+    login.php
+    register.php
+    logout.php
+    forgot-password.php
+    reset-password.php
+  /products/
+    create.php
+    update.php
+    delete.php
+    list.php
+    import.php
+  /collections/
+    create.php
+    update.php
+    delete.php
+    list.php
+  /orders/
+    create.php
+    update-status.php
+    delete.php
+    list.php
+  /customers/
+    create.php
+    update.php
+    list.php
+  /discounts/
+    create.php
+    update.php
+    delete.php
+    list.php
+  /themes/
+    save-layout.php
+    load-layout.php
+    save-settings.php
+    get-schema.php
+    upload-assets.php
+    upload-image.php
+  /search/
+    index.php
+  /webhooks/
+    order-status-updated.php
+    product-stock-updated.php
+  /utils/
+    send-mail.php
+    send-sms.php
+    compress-image.php
+    (uses csrf_token helper for form security)
+
+/api/
+  auth.php
+  products.php
+  orders.php
+  customers.php
+  theme.php
+  discounts.php
+
+/uploads/
+  /themes/
+    /default/
+      /images/
+      /fonts/
+  /products/
+  /banners/
+  /avatars/
+  /others/
+```
+
+This layout mirrors a minimal Shopify-style theme system with a corresponding admin backend.
+
+## Recent Updates
+
+- Added rate limiting and reCAPTCHA verification to admin authentication endpoints.
+- Introduced product reviews system with new API (`api/reviews.php`) and backend endpoint (`backend/reviews/create.php`).
+- Theme now includes a `product-reviews` section to display customer feedback on product pages.
+- Admin login now requires a second-factor verification code sent via email.
+- Production `.htaccess` forces HTTPS and disables PHP error display.
+- Added wishlist API (`api/wishlist.php`) with theme buttons for users to save favorite products.
+- Implemented persistent sessions for carts and new helpers to track recently viewed products.
+- Added `recently-viewed` section to display the user's browsing history.
+- Introduced product comparison via `api/compare.php` with session-based compare list and a new `compare.php` template.
+- Implemented CSRF tokens on authentication forms for increased security.
+- Added dynamic product CSV importer with automatic column mapping and sample feed generator.
+- Created a dedicated admin page for importing products with drag/drop CSV upload and column mapping preview.
+- Added standalone product edit page for managing details, variants and images.
+- Added product sets management with API endpoints and admin page to create sets.
+- Introduced collection builder pages for creating and editing collections with manual and smart product assignment.
+- Implemented product search autocomplete with new `api/search.php` endpoint and header search bar.
+- Added a simple page builder storing section layouts in a new `layout` field for pages.
+- New theme settings table stores per-theme key/value pairs editable from the Theme Settings page.
+- Pages now track versions with `layout_draft` and `layout_published` columns and a new `page_versions` table.
+- Added per-page code injection fields and a new `custom-code` section for raw HTML/CSS/JS.
+- Introduced section presets and page templates with new admin pages to manage them.
+- Added migrations `012_create_section_presets.sql` and `013_create_page_templates.sql`.
+- Created basic multi-step checkout flow with cart, address, payment, and success pages.
+- Added device-aware rendering via `applyResponsiveSettings` and user agent detection.
+- Added sticky add-to-cart bar on product pages for improved mobile UX.
+- Added cookie consent banner and localStorage tracking for GDPR compliance.
+- Captures UTM campaign parameters into session and stores them on orders (migration `021_add_utm_columns_to_orders.sql`).
+
+## Database Migrations
+Run the SQL files in the `migrations/` directory in order to set up or update the database schema. Recent migrations include `005_extend_product_sets.sql` for product sets, `006_extend_collections.sql` for collection metadata, and `007_create_collection_rules.sql` for smart collection rules.
+`009_add_versioning_to_pages.sql` introduces draft/published layouts and version tracking. `010_create_page_versions.sql` stores historical snapshots.
+`011_add_custom_code_to_pages.sql` adds head/body/script fields for injecting code per page.
+`012_create_section_presets.sql` defines a table for saved section presets.
+`013_create_page_templates.sql` defines a table for reusable page templates.
+`017_create_global_sections.sql` stores shared sections used across pages.
+`018_create_post_order_offers.sql` adds tables for checkout upsell products.
+`019_extend_global_sections.sql` adds a `used_on_pages` column to track where each global section is used.
+- Implemented email logging and behavior event tracking with new API (`api/events.php`) and migrations for `email_logs`, `user_events`, and `email_campaigns`.
+- Added global sections system allowing shared content blocks across pages (`global_sections` table).
+- Checkout success page now reads settings from `checkout_success.json` and supports upsell products.
+- Added activity logs for admin actions with new `activity_logs` table and log viewer page.
+- Added admin pages for managing checkout success content and editing global section usage lists.
+- Added migration `021_add_utm_columns_to_orders.sql` for storing UTM parameters on orders.
+- Added cookie consent banner for GDPR compliance.
+- Added additional security headers (Referrer-Policy, Permissions-Policy, X-Permitted-Cross-Domain-Policies)
+- Introduced single-level admin navigation with slide-out panels for quick access to sections.
+- Added placeholder admin pages for Products, Orders, Customers, Pages & Content,
+  Reports, Settings, and Theme Editor to support the new navigation.

--- a/admin/assets/admin.css
+++ b/admin/assets/admin.css
@@ -1,0 +1,227 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f6f8;
+    color: #333;
+}
+
+
+h1 {
+    font-size: 2rem;
+    margin-bottom: 20px;
+}
+
+nav {
+    background-color: #2c3e50;
+    padding: 10px 20px;
+}
+
+nav a {
+    color: #ecf0f1;
+    text-decoration: none;
+    margin-right: 15px;
+    font-weight: bold;
+}
+
+nav a:hover {
+    text-decoration: underline;
+}
+
+button {
+    background-color: #3498db;
+    border: none;
+    color: white;
+    padding: 10px 15px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+}
+
+button:hover {
+    background-color: #2980b9;
+}
+
+input, select, textarea {
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 15px;
+}
+
+.dropzone {
+    border: 2px dashed #ccc;
+    padding: 40px;
+    text-align: center;
+    cursor: pointer;
+    margin-bottom: 15px;
+    position: relative;
+}
+.dropzone.drag {
+    background: #f0f8ff;
+}
+.dropzone input[type="file"] {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+}
+
+#progress {
+    width: 100%;
+    background: #eee;
+    border-radius: 4px;
+    margin-top: 10px;
+    height: 20px;
+}
+#progress #bar {
+    height: 100%;
+    width: 0;
+    background: #3498db;
+    border-radius: 4px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+}
+
+table th, table td {
+    border: 1px solid #ddd;
+    padding: 10px;
+    text-align: left;
+}
+
+table th {
+    background-color: #f8f8f8;
+}
+
+@media (max-width: 768px) {
+    .content {
+        margin: 10px;
+        padding: 10px;
+    }
+
+    nav a {
+        display: block;
+        margin: 10px 0;
+    }
+}
+.settings-wrapper{display:flex;gap:20px;}
+.settings-menu ul{list-style:none;padding:0;width:200px;}
+.settings-menu li{margin-bottom:5px;}
+.settings-menu a{text-decoration:none;}
+.settings-content{flex:1;}
+.setting-row{margin-bottom:10px;display:flex;align-items:center;gap:10px;}
+.setting-row label{min-width:150px;}
+
+/* New styles for admin dashboard layout */
+
+body, html {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  display: flex;
+  flex-direction: row;
+  height: 100vh;
+}
+
+.sidebar {
+  width: 250px;
+  background-color: #2c3e50;
+  color: white;
+  overflow-y: auto;
+  padding: 10px 0;
+}
+
+.nav-group {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.nav-item {
+  padding: 10px 20px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.nav-item:hover {
+  background-color: #34495e;
+}
+
+.nav-item > ul.sub-nav {
+  list-style: none;
+  padding-left: 15px;
+  margin: 5px 0 10px 0;
+  display: none;
+}
+
+.nav-item.expanded > ul.sub-nav {
+  display: block;
+}
+
+.sub-nav li {
+  padding: 5px 20px;
+}
+
+.sub-nav li a {
+  color: white;
+  text-decoration: none;
+  display: block;
+}
+
+.sub-nav li a:hover {
+  background-color: #3d566e;
+}
+
+.content {
+  flex-grow: 1;
+  flex-direction: column;
+  padding: 20px;
+  overflow-y: auto;
+  background-color: #ecf0f1;
+}
+
+#main {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.panel {
+  width: 0;
+  transition: width 0.3s;
+  background: #fff;
+  box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+  overflow-y: auto;
+}
+
+.panel iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+.panel.open {
+  width: 600px;
+}
+
+.dash-section {
+  background: #fff;
+  padding: 15px;
+  margin-bottom: 20px;
+  border-radius: 6px;
+  box-shadow: 0 0 5px rgba(0,0,0,0.05);
+}
+.dash-section h2 { margin-top: 0; }

--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -1,0 +1,23 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const panel = document.getElementById('panel');
+  document.querySelectorAll('.nav-item[data-url]').forEach(item => {
+    item.addEventListener('click', () => {
+      const url = item.dataset.url;
+      if (item.dataset.external === '1') {
+        window.open(url, '_blank');
+        return;
+      }
+      if (panel) {
+        panel.innerHTML = `<iframe src="${url}"></iframe>`;
+        panel.classList.add('open');
+      }
+    });
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape' && panel.classList.contains('open')) {
+      panel.classList.remove('open');
+      panel.innerHTML = '';
+    }
+  });
+});

--- a/admin/components/footer.php
+++ b/admin/components/footer.php
@@ -1,0 +1,7 @@
+</div>
+<div id="panel" class="panel"></div>
+</div>
+</div>
+<script src="/admin/assets/admin.js"></script>
+</body>
+</html>

--- a/admin/components/header.php
+++ b/admin/components/header.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?php echo isset($pageTitle) ? htmlspecialchars($pageTitle) : 'Admin'; ?></title>
+    <link rel="stylesheet" href="/admin/assets/admin.css">
+    <link rel="icon" href="/admin/assets/favicon.ico" type="image/x-icon">
+</head>
+<body>
+<div class="container">
+<?php include __DIR__ . '/nav.php'; ?>
+<div id="main">
+<div class="content">

--- a/admin/components/nav.php
+++ b/admin/components/nav.php
@@ -1,0 +1,14 @@
+<div class="sidebar">
+  <ul class="nav-group">
+    <li class="nav-item" data-url="/admin/dashboard/dashboard.php">Dashboard</li>
+    <li class="nav-item" data-url="/admin/products/products.php">Products</li>
+    <li class="nav-item" data-url="/admin/orders/orders.php">Orders</li>
+    <li class="nav-item" data-url="/admin/customers/customers.php">Customers</li>
+    <li class="nav-item" data-url="/admin/marketing/marketing.php">Marketing</li>
+    <li class="nav-item" data-url="/admin/themes/theme-editor.php" data-external="1">Theme Editor</li>
+    <li class="nav-item" data-url="/admin/pages/pages.php">Pages &amp; Content</li>
+    <li class="nav-item" data-url="/admin/reports/reports.php">Reports</li>
+    <li class="nav-item" data-url="/admin/settings/settings.php">Settings</li>
+    <li class="nav-item"><a href="/backend/auth/logout.php">Logout</a></li>
+  </ul>
+</div>

--- a/admin/customers/customers.php
+++ b/admin/customers/customers.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Customers';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Customers Panel</h1>
+<p>This is a placeholder for customer management.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/dashboard/dashboard.php
+++ b/admin/dashboard/dashboard.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Dashboard';
+
+$totalCustomers = db_query('SELECT COUNT(*) FROM customers')->fetchColumn();
+$totalOrders = db_query('SELECT COUNT(*) FROM orders')->fetchColumn();
+$totalProducts = db_query('SELECT COUNT(*) FROM products')->fetchColumn();
+$totalRevenue = db_query('SELECT SUM(total_amount) FROM orders WHERE status = "completed"')->fetchColumn();
+
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Dashboard</h1>
+<section class="dash-section">
+  <h2>Sales Overview</h2>
+  <p>Total Revenue: $<?= number_format((float)$totalRevenue, 2) ?></p>
+  <p>Total Orders: <?= (int)$totalOrders ?></p>
+  <p>Average Order Value: <?= $totalOrders ? number_format((float)$totalRevenue/$totalOrders, 2) : 0 ?></p>
+</section>
+<section class="dash-section">
+  <h2>Orders Overview</h2>
+  <p>Pending Orders: <!-- placeholder --></p>
+</section>
+<section class="dash-section">
+  <h2>Customers Overview</h2>
+  <p>Total Customers: <?= (int)$totalCustomers ?></p>
+</section>
+<section class="dash-section">
+  <h2>Traffic &amp; Conversion</h2>
+  <p><!-- placeholder --></p>
+</section>
+<section class="dash-section">
+  <h2>Product Performance</h2>
+  <p>Total Products: <?= (int)$totalProducts ?></p>
+</section>
+<section class="dash-section">
+  <h2>Campaign Highlights</h2>
+  <p><!-- placeholder --></p>
+</section>
+<section class="dash-section">
+  <h2>Live Notifications / Tasks</h2>
+  <p><!-- placeholder --></p>
+</section>
+<section class="dash-section">
+  <h2>Revenue Heatmap</h2>
+  <p><!-- placeholder --></p>
+</section>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/marketing/marketing.php
+++ b/admin/marketing/marketing.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Marketing';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Marketing Panel</h1>
+<p>This is a placeholder for marketing analytics and tools.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/orders/orders.php
+++ b/admin/orders/orders.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Orders';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Orders Panel</h1>
+<p>This is a placeholder for order management.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/pages/pages.php
+++ b/admin/pages/pages.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Pages & Content';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Pages &amp; Content</h1>
+<p>This is a placeholder for pages and content management.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/products/products.php
+++ b/admin/products/products.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Products';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Products Panel</h1>
+<p>This is a placeholder for product management.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/reports/reports.php
+++ b/admin/reports/reports.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Reports';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Reports Panel</h1>
+<p>This is a placeholder for reports and analytics.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/settings/settings.php
+++ b/admin/settings/settings.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Settings';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Settings Panel</h1>
+<p>This is a placeholder for store settings.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/themes/theme-editor.php
+++ b/admin/themes/theme-editor.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Theme Editor';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Theme Editor</h1>
+<p>This is a placeholder for editing theme settings and templates.</p>
+<?php require __DIR__ . '/../components/footer.php'; ?>


### PR DESCRIPTION
## Summary
- add single-level sidebar navigation and right-side panel
- implement panel toggling logic in `admin.js`
- update styles for dashboard layout and panels
- create placeholder Marketing panel
- restructure dashboard page with section cards
- document new admin navigation in README
- add placeholder admin pages for all navigation items

## Testing
- `php -l admin/marketing/marketing.php`
- `php -l admin/components/header.php`
- `php -l admin/components/footer.php`
- `php -l admin/dashboard/dashboard.php`
- `php -l admin/products/products.php`
- `php -l admin/orders/orders.php`
- `php -l admin/customers/customers.php`
- `php -l admin/pages/pages.php`
- `php -l admin/reports/reports.php`
- `php -l admin/settings/settings.php`
- `php -l admin/themes/theme-editor.php`
- `npm install` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873ab0352c8832884254458c5f39f01