### PR TITLE
Expand admin nav and add overview pages

### DIFF
--- a/admin/activity/activity_log.php
+++ b/admin/activity/activity_log.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+
+
+
+
+$logs = db_query('SELECT activity_logs.*, users.email FROM activity_logs LEFT JOIN users ON activity_logs.user_id = users.id ORDER BY activity_logs.created_at DESC LIMIT 100')->fetchAll();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Activity Log</title>
+    <link rel="stylesheet" href="/admin/assets/admin.css">
+</head>
+<body>
+<?php include __DIR__ . '/../components/header.php'; ?>
+<h1>Activity Log</h1>
+<table class="admin-table">
+    <thead>
+        <tr>
+            <th>Time</th>
+            <th>User</th>
+            <th>Action</th>
+            <th>Metadata</th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($logs as $log): ?>
+        <tr>
+            <td><?= htmlspecialchars($log['created_at']) ?></td>
+            <td><?= htmlspecialchars($log['email'] ?? 'System') ?></td>
+            <td><?= htmlspecialchars($log['action']) ?></td>
+            <td><pre><?= htmlspecialchars($log['metadata']) ?></pre></td>
+        </tr>
+    <?php endforeach; ?>
+    </tbody>
+</table>
+<?php include __DIR__ . '/../components/footer.php'; ?>
+</body>
+</html>

--- a/admin/activity/index.php
+++ b/admin/activity/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Activity Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Activity</h1>
+<p>Quick links:</p>
+<ul>
+  <li><a href="activity_log.php">View Activity Log</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/assets/admin.css
+++ b/admin/assets/admin.css
@@ -156,6 +156,16 @@ body, html {
   user-select: none;
 }
 
+.nav-item > a {
+  color: white;
+  text-decoration: none;
+  display: block;
+}
+
+.nav-item > a:hover {
+  text-decoration: underline;
+}
+
 .nav-item:hover {
   background-color: #34495e;
 }
@@ -183,6 +193,11 @@ body, html {
 
 .sub-nav li a:hover {
   background-color: #3d566e;
+}
+
+.nav-item > a.active,
+.sub-nav li a.active {
+  font-weight: bold;
 }
 
 .content {

--- a/admin/assets/admin.js
+++ b/admin/assets/admin.js
@@ -1,23 +1,28 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const panel = document.getElementById('panel');
-  document.querySelectorAll('.nav-item[data-url]').forEach(item => {
-    item.addEventListener('click', () => {
-      const url = item.dataset.url;
-      if (item.dataset.external === '1') {
-        window.open(url, '_blank');
-        return;
-      }
-      if (panel) {
-        panel.innerHTML = `<iframe src="${url}"></iframe>`;
-        panel.classList.add('open');
+  const navItems = document.querySelectorAll('.nav-item');
+  const current = window.location.pathname;
+
+  navItems.forEach(item => {
+    const parentLink = item.querySelector(':scope > a');
+    const subLinks = item.querySelectorAll('.sub-nav a');
+
+    // expand if current page matches parent or a sub link
+    if (parentLink && parentLink.getAttribute('href') === current) {
+      item.classList.add('expanded');
+      parentLink.classList.add('active');
+    }
+    subLinks.forEach(link => {
+      if (link.getAttribute('href') === current) {
+        item.classList.add('expanded');
+        link.classList.add('active');
       }
     });
-  });
 
-  document.addEventListener('keydown', e => {
-    if (e.key === 'Escape' && panel.classList.contains('open')) {
-      panel.classList.remove('open');
-      panel.innerHTML = '';
-    }
+    item.addEventListener('click', e => {
+      if (e.target.closest('.sub-nav')) {
+        return; // don't toggle when clicking sub nav links
+      }
+      item.classList.toggle('expanded');
+    });
   });
 });

--- a/admin/assets/theme-editor.css
+++ b/admin/assets/theme-editor.css
@@ -1,0 +1,514 @@
+:root {
+  --primary: #4a7aff;
+  --primary-dark: #274fe8;
+  --bg: #f1f3f8;
+  --sidebar-bg: #ffffff;
+  --text: #333;
+  --header-height: 60px;
+  --radius: 8px;
+  --spacing: 12px;
+  --sidebar-width: 380px;
+}
+
+/* General body and container */
+body.theme-editor {
+  font-family: "Inter", "Segoe UI", Helvetica, Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+/* Editor header */
+.editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: linear-gradient(90deg, #fff 0%, #f5f7fc 100%);
+  padding: var(--spacing) calc(var(--spacing) * 1.5);
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  min-height: var(--header-height);
+  border-radius: 0 0 var(--radius) var(--radius);
+}
+
+.editor-header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #222;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.header-actions select {
+  padding: 6px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  background-color: #fff;
+}
+
+.header-actions button {
+  padding: 8px 16px;
+  background-color: var(--primary);
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.header-actions button:hover {
+  background-color: var(--primary-dark);
+}
+
+.device-toggle {
+  display: inline-flex;
+  border: 1px solid #d1d5db;
+  border-radius: 20px;
+  overflow: hidden;
+}
+.device-toggle button {
+  padding: 6px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: #374151;
+}
+.device-toggle button + button {
+  border-left: 1px solid #d1d5db;
+}
+.device-toggle button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.container {
+  display: flex;
+  height: calc(100vh - var(--header-height));
+  overflow: hidden;
+}
+
+/* Sidebar styles */
+.sidebar {
+  width: var(--sidebar-width);
+  border-right: 1px solid #e5e7eb;
+  padding: calc(var(--spacing) * 1.5);
+  background-color: var(--sidebar-bg);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  box-shadow: 2px 0 6px rgba(0,0,0,0.05);
+  border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.sidebar-search {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  z-index: 2;
+}
+
+.sidebar-search input {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+
+.sidebar h2, .sidebar h3 {
+  margin-top: 0;
+  font-weight: 600;
+  color: #222;
+}
+
+#page-select, #add-section-select {
+  width: 100%;
+  padding: 8px 10px;
+  margin: 10px 0 15px 0;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 1rem;
+  background-color: #fff;
+  box-sizing: border-box;
+}
+
+.editor-header #page-select {
+  width: auto;
+  margin: 0;
+}
+
+#section-list {
+  flex-grow: 1;
+  overflow-y: auto;
+  margin-bottom: calc(var(--spacing) * 2);
+  padding: 0;
+}
+
+.section-group {
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.section-group-header {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #6B7280;
+  font-weight: 600;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.section-group-header .chevron {
+  margin-left: auto;
+  transition: transform 0.2s;
+  color: #9CA3AF;
+}
+
+.section-group.collapsed .section-group-header .chevron {
+  transform: rotate(-90deg);
+}
+.section-group.collapsed .section-group-list {
+  display: none;
+}
+
+.section-group-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.section-item {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  color: #111827;
+  cursor: move;
+  border-left: 3px solid transparent;
+}
+.te-sidebar ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+
+.section-item:hover {
+  background-color: #F9FAFB;
+}
+
+.section-item.active {
+  background-color: #F3F4F6;
+  border-left-color: #3B82F6;
+}
+
+.section-item .actions {
+  margin-left: auto;
+  display: none;
+  gap: 8px;
+}
+
+.section-item:hover .actions {
+  display: inline-flex;
+}
+
+.section-item .actions button {
+  background: transparent;
+  border: none;
+  color: #9CA3AF;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.section-item .actions button:hover {
+  color: #374151;
+}
+
+.block-list {
+  list-style: none;
+  padding-left: 24px;
+  margin-top: 6px;
+}
+
+.block-item {
+  padding: 8px 24px;
+  margin-bottom: 4px;
+  font-weight: 500;
+  color: #374151;
+  cursor: move;
+}
+
+/* Add section controls */
+.add-section {
+  margin-bottom: calc(var(--spacing) * 2);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
+}
+
+.add-section-inline {
+  width: calc(100% - 32px);
+  margin: 8px 16px;
+  padding: 6px 0;
+  border: 1px dashed #cbd5e1;
+  border-radius: 4px;
+  background: transparent;
+  color: #3B82F6;
+  text-align: center;
+  cursor: pointer;
+  font-weight: 500;
+  position: relative;
+}
+.add-section-inline::before {
+  content: '+';
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.add-section label {
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.add-section select {
+  flex-grow: 1;
+  padding: var(--spacing);
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+  font-size: 1rem;
+}
+
+.add-section button {
+  padding: var(--spacing) calc(var(--spacing) * 1.5);
+  background-color: var(--primary);
+  border: none;
+  color: white;
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.add-section button:hover {
+  background-color: var(--primary-dark);
+}
+
+/* Version history */
+#version-history {
+  border-top: 1px solid #e5e7eb;
+  padding-top: 15px;
+  margin-top: auto;
+}
+
+#version-list {
+  list-style: none;
+  padding-left: 0;
+  max-height: 160px;
+  overflow-y: auto;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+#version-list li {
+  padding: 6px 8px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+/* Content area */
+.content {
+  flex: 1;
+  padding: 20px;
+  overflow-y: auto;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.content h2 {
+  margin-top: 0;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 15px;
+  font-size: 1.2rem;
+}
+
+/* Preview iframe */
+#preview-frame {
+  width: 100%;
+  height: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #fff;
+}
+
+/* Customizer panel */
+#section-customizer {
+  flex-grow: 1;
+  padding: calc(var(--spacing) * 1.5);
+  border-top: 1px solid #e5e7eb;
+  overflow-y: auto;
+  background-color: #f9f9f9;
+  border-radius: var(--radius);
+  margin-top: var(--spacing);
+}
+
+#section-customizer label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: #333;
+}
+
+#section-customizer input[type="text"],
+#section-customizer textarea,
+#section-customizer select {
+  width: 100%;
+  padding: var(--spacing);
+  margin-bottom: var(--spacing);
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+#section-customizer textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+#section-customizer button {
+  padding: var(--spacing) calc(var(--spacing) * 1.5);
+  background-color: var(--primary);
+  border: none;
+  color: white;
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+#section-customizer button:hover {
+  background-color: var(--primary-dark);
+}
+
+/* Back to sections button */
+#back-to-sections-btn {
+  background-color: #6c757d;
+  color: white;
+  border: none;
+  padding: var(--spacing) calc(var(--spacing) * 1.5);
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  margin-bottom: var(--spacing);
+  transition: background-color 0.3s ease;
+}
+
+#back-to-sections-btn:hover {
+  background-color: #565e64;
+}
+
+/* Add Section modal */
+#add-section-modal {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#add-section-modal .modal-content {
+  background: #fff;
+  padding: calc(var(--spacing) * 1.5);
+  max-height: 80vh;
+  overflow-y: auto;
+  width: 440px;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  position: relative;
+}
+
+#add-section-modal .close-modal {
+  position: absolute;
+  right: var(--spacing);
+  top: var(--spacing);
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+#add-section-modal #section-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
+  margin-top: var(--spacing);
+}
+
+#add-section-modal .section-card {
+  border: 1px solid #d1d5db;
+  padding: var(--spacing);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
+  border-radius: var(--radius);
+  transition: background-color 0.2s ease;
+}
+
+#add-section-modal .section-card:hover {
+  background-color: #f0f4ff;
+}
+
+#add-section-modal .section-card img {
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 3px;
+}
+
+#add-section-modal input[type="text"] {
+  width: 100%;
+  padding: var(--spacing);
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    height: 300px;
+    border-right: none;
+    border-bottom: 1px solid #d1d5db;
+    border-radius: 0 0 var(--radius) var(--radius);
+  }
+  .content {
+    height: calc(100vh - 300px);
+  }
+  #preview-frame {
+    height: 100%;
+  }
+}

--- a/admin/assets/theme-editor.js
+++ b/admin/assets/theme-editor.js
@@ -1,0 +1,64 @@
+function renderList(){
+  const ul=document.getElementById('section-list');
+  ul.innerHTML='';
+  window.layout.order.forEach(key=>{
+    const sec=window.layout.sections[key];
+    if(!sec) return;
+    const li=document.createElement('li');
+    li.dataset.key=key;
+    li.innerHTML=`<span>${sec.type}</span><span class="drag-handle">☰</span>`;
+    ul.appendChild(li);
+  });
+  Sortable.create(ul,{handle:'.drag-handle',animation:150,onEnd:updateOrder});
+}
+function updateOrder(evt){
+  const keys=[...document.querySelectorAll('#section-list li')].map(li=>li.dataset.key);
+  window.layout.order=keys;
+}
+function openAddModal(){
+  document.getElementById('add-section-modal').classList.add('show');
+  document.getElementById('section-search').value='';
+  filterSections('');
+}
+
+function closeModal(){
+  document.getElementById('add-section-modal').classList.remove('show');
+}
+
+function filterSections(q){
+  document.querySelectorAll('#add-section-modal .section-card').forEach(card=>{
+    const title=card.querySelector('h4').innerText.toLowerCase();
+    card.style.display=title.includes(q.toLowerCase())?'':'none';
+  });
+}
+
+function addSection(type){
+  fetch(`/themes/default/sections/${type}.schema.json`).then(r=>r.json()).then(schema=>{
+    const sec={type:type,settings:{}};
+    (schema.settings||[]).forEach(f=>{sec.settings[f.id]=f.default||'';});
+    const key=type+'_'+Date.now();
+    window.layout.sections[key]=sec;
+    window.layout.order.push(key);
+    renderList();
+    saveLayout();
+  }).catch(()=>{
+    const key=type+'_'+Date.now();
+    window.layout.sections[key]={type:type,settings:{}};
+    window.layout.order.push(key);
+    renderList();
+    saveLayout();
+  });
+  closeModal();
+}
+function saveLayout(){
+  fetch('/backend/themes/save-layout.php',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({theme_id:window.themeId,layout_json:JSON.stringify(window.layout)})}).then(r=>r.json()).then(d=>{if(d.success){document.getElementById('preview-frame').contentWindow.location.reload();}});
+}
+
+document.getElementById('add-section-btn').addEventListener('click',openAddModal);
+document.getElementById('section-search').addEventListener('input',e=>filterSections(e.target.value));
+document.querySelector('#add-section-modal .close-modal').addEventListener('click',closeModal);
+document.querySelectorAll('#add-section-modal .section-card').forEach(card=>{
+  card.addEventListener('click',()=>addSection(card.dataset.type));
+});
+document.getElementById('save-layout').addEventListener('click',saveLayout);
+renderList();

--- a/admin/components/nav.php
+++ b/admin/components/nav.php
@@ -1,14 +1,75 @@
 <div class="sidebar">
   <ul class="nav-group">
-    <li class="nav-item" data-url="/admin/dashboard/dashboard.php">Dashboard</li>
-    <li class="nav-item" data-url="/admin/products/products.php">Products</li>
-    <li class="nav-item" data-url="/admin/orders/orders.php">Orders</li>
-    <li class="nav-item" data-url="/admin/customers/customers.php">Customers</li>
-    <li class="nav-item" data-url="/admin/marketing/marketing.php">Marketing</li>
-    <li class="nav-item" data-url="/admin/themes/theme-editor.php" data-external="1">Theme Editor</li>
-    <li class="nav-item" data-url="/admin/pages/pages.php">Pages &amp; Content</li>
-    <li class="nav-item" data-url="/admin/reports/reports.php">Reports</li>
-    <li class="nav-item" data-url="/admin/settings/settings.php">Settings</li>
+    <li class="nav-item"><a href="/admin/dashboard/dashboard.php">Dashboard</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/dashboard/dashboard.php">Dashboard</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/activity/index.php">Activity</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/activity/activity_log.php">Activity Log</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/products/index.php">Products</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/products/products.php">Products</a></li>
+        <li><a href="/admin/products/collections.php">Collections</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/orders/index.php">Orders</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/orders/orders.php">Orders</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/customers/index.php">Customers</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/customers/customers.php">Customers</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/discounts/index.php">Discounts</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/discounts/discounts.php">Discounts</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/pages/index.php">Pages</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/pages/pages.php">Pages</a></li>
+        <li><a href="/admin/pages/templates.php">Page Templates</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/reports/index.php">Reports</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/reports/reports.php">Reports</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/settings/index.php">Settings</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/settings/settings.php">Settings</a></li>
+        <li><a href="/admin/settings/checkout_settings.php">Checkout Success</a></li>
+        <li><a href="/admin/settings/presets.php">Section Presets</a></li>
+        <li><a href="/admin/settings/global_sections.php">Global Sections</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/themes/index.php">Themes</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/themes/themes.php">Themes</a></li>
+        <li><a href="/admin/themes/theme-editor.php" target="_blank">Theme Editor</a></li>
+        <li><a href="/admin/editor/theme-settings.php">Theme Settings</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/plugins/index.php">Plugins</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/plugins/plugins.php">Plugins</a></li>
+        <li><a href="/admin/plugins/plugins_add.php">Add Plugin</a></li>
+        <li><a href="/admin/plugins/plugins_delete.php">Delete Plugin</a></li>
+        <li><a href="/admin/plugins/plugins_toggle.php">Toggle Plugin</a></li>
+      </ul>
+    </li>
+    <li class="nav-item"><a href="/admin/marketing/index.php">Marketing</a>
+      <ul class="sub-nav">
+        <li><a href="/admin/marketing/marketing.php">Marketing Dashboard</a></li>
+      </ul>
+    </li>
     <li class="nav-item"><a href="/backend/auth/logout.php">Logout</a></li>
   </ul>
 </div>

--- a/admin/customers/customers.php
+++ b/admin/customers/customers.php
@@ -1,0 +1,113 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Customers';
+
+// Handle form submissions for adding/editing/deleting customers
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $id = $_POST['id'] ?? null;
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+
+    if ($action === 'add' && $name && $email) {
+        db_query('INSERT INTO customers (name, email, created_at) VALUES (:name, :email, NOW())', [
+            ':name' => $name,
+            ':email' => $email,
+        ]);
+        $_SESSION['flash_message'] = 'Customer added successfully.';
+    } elseif ($action === 'edit' && $id && $name && $email) {
+        db_query('UPDATE customers SET name = :name, email = :email WHERE id = :id', [
+            ':name' => $name,
+            ':email' => $email,
+            ':id' => $id,
+        ]);
+        $_SESSION['flash_message'] = 'Customer updated successfully.';
+    } elseif ($action === 'delete' && $id) {
+        db_query('DELETE FROM customers WHERE id = :id', [':id' => $id]);
+        $_SESSION['flash_message'] = 'Customer deleted successfully.';
+    }
+    header('Location: /admin/customers.php');
+    exit;
+}
+
+// Fetch all customers
+$customers = db_query('SELECT id, first_name, last_name, email, created_at FROM customers ORDER BY created_at DESC')->fetchAll();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Customers</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<!-- Customer list -->
+<table>
+    <thead>
+        <tr>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Email</th>
+            <th>Created At</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($customers as $customer): ?>
+        <tr>
+            <td><?= htmlspecialchars($customer['first_name']) ?></td>
+            <td><?= htmlspecialchars($customer['last_name']) ?></td>
+            <td><?= htmlspecialchars($customer['email']) ?></td>
+            <td><?= htmlspecialchars($customer['created_at']) ?></td>
+            <td>
+                <a href="/admin/customers.php?action=edit&id=<?= $customer['id'] ?>">Edit</a> |
+                <form method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this customer?');">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="id" value="<?= $customer['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<!-- Add/Edit form -->
+<?php
+$editCustomer = null;
+if (isset($_GET['action']) && $_GET['action'] === 'edit' && isset($_GET['id'])) {
+    $editCustomer = db_query('SELECT id, first_name, last_name, email FROM customers WHERE id = :id', [':id' => $_GET['id']])->fetch();
+}
+?>
+
+<h2><?= $editCustomer ? 'Edit Customer' : 'Add New Customer' ?></h2>
+<form method="post">
+    <input type="hidden" name="action" value="<?= $editCustomer ? 'edit' : 'add' ?>">
+    <?php if ($editCustomer): ?>
+        <input type="hidden" name="id" value="<?= $editCustomer['id'] ?>">
+    <?php endif; ?>
+    <label for="first_name">First Name:</label><br>
+    <input type="text" id="first_name" name="first_name" required value="<?= $editCustomer ? htmlspecialchars($editCustomer['first_name']) : '' ?>"><br><br>
+    <label for="last_name">Last Name:</label><br>
+    <input type="text" id="last_name" name="last_name" required value="<?= $editCustomer ? htmlspecialchars($editCustomer['last_name']) : '' ?>"><br><br>
+    <label for="email">Email:</label><br>
+    <input type="email" id="email" name="email" required value="<?= $editCustomer ? htmlspecialchars($editCustomer['email']) : '' ?>"><br><br>
+    <button type="submit"><?= $editCustomer ? 'Update' : 'Add' ?> Customer</button>
+</form>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/customers/index.php
+++ b/admin/customers/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Customers Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Customers</h1>
+<p>Manage your customer base.</p>
+<ul>
+  <li><a href="customers.php">Customers</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/discounts/discounts.php
+++ b/admin/discounts/discounts.php
@@ -1,0 +1,256 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Discounts and Sales';
+
+// Handle form submissions for adding/editing/deleting discounts and sales
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $id = $_POST['id'] ?? null;
+    $code = trim($_POST['code'] ?? '');
+    $discount_percent = floatval($_POST['discount_percent'] ?? 0);
+    $active = isset($_POST['active']) ? 1 : 0;
+    $apply_to = $_POST['apply_to'] ?? 'all'; // all, products, sets, collections
+    $product_ids = $_POST['product_ids'] ?? [];
+    $set_ids = $_POST['set_ids'] ?? [];
+    $collection_ids = $_POST['collection_ids'] ?? [];
+    $is_sale = isset($_POST['is_sale']) ? 1 : 0; // New: Check if it's a sale
+
+    if ($action === 'add' && $code && $discount_percent > 0) {
+        db_query('INSERT INTO discounts (code, discount_percent, active, apply_to, is_sale, created_at) VALUES (:code, :discount_percent, :active, :apply_to, :is_sale, NOW())', [
+            ':code' => $code,
+            ':discount_percent' => $discount_percent,
+            ':active' => $active,
+            ':apply_to' => $apply_to,
+            ':is_sale' => $is_sale, // New: Save is_sale status
+        ]);
+        $discount_id = db_last_insert_id();
+
+        // Apply discount/sale to selected products, sets, or collections
+        if ($apply_to === 'products') {
+            foreach ($product_ids as $product_id) {
+                db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                    ':product_id' => $product_id,
+                    ':discount_id' => $discount_id,
+                ]);
+            }
+        } elseif ($apply_to === 'sets') {
+            foreach ($set_ids as $set_id) {
+                // Assuming you have a table called product_set_products
+                $product_ids = db_query('SELECT product_id FROM product_set_products WHERE set_id = :set_id', [':set_id' => $set_id])->fetchAll(PDO::FETCH_COLUMN);
+                foreach ($product_ids as $product_id) {
+                     db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                        ':product_id' => $product_id,
+                        ':discount_id' => $discount_id,
+                    ]);
+                }
+            }
+        } elseif ($apply_to === 'collections') {
+            foreach ($collection_ids as $collection_id) {
+                $product_ids = db_query('SELECT product_id FROM collection_products WHERE collection_id = :collection_id', [':collection_id' => $collection_id])->fetchAll(PDO::FETCH_COLUMN);
+                foreach ($product_ids as $product_id) {
+                    db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                        ':product_id' => $product_id,
+                        ':discount_id' => $discount_id,
+                    ]);
+                }
+            }
+        }
+
+        $_SESSION['flash_message'] = $is_sale ? 'Sale added successfully.' : 'Discount added successfully.';
+    } elseif ($action === 'edit' && $id && $code && $discount_percent > 0) {
+        // Update discount/sale details
+        db_query('UPDATE discounts SET code = :code, discount_percent = :discount_percent, active = :active, apply_to = :apply_to, is_sale = :is_sale WHERE id = :id', [
+            ':code' => $code,
+            ':discount_percent' => $discount_percent,
+            ':active' => $active,
+            ':apply_to' => $apply_to,
+            ':is_sale' => $is_sale, // New: Update is_sale status
+            ':id' => $id,
+        ]);
+
+        // Clear existing product_discounts for this discount/sale
+         db_query('DELETE FROM product_discounts WHERE discount_id = :discount_id', [':discount_id' => $id]);
+
+        if ($apply_to === 'products') {
+            foreach ($product_ids as $product_id) {
+                db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                    ':product_id' => $product_id,
+                    ':discount_id' => $id,
+                ]);
+            }
+        } elseif ($apply_to === 'sets') {
+            foreach ($set_ids as $set_id) {
+                // Assuming you have a table called product_set_products
+                $product_ids = db_query('SELECT product_id FROM product_set_products WHERE set_id = :set_id', [':set_id' => $set_id])->fetchAll(PDO::FETCH_COLUMN);
+                foreach ($product_ids as $product_id) {
+                     db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                        ':product_id' => $product_id,
+                        ':discount_id' => $id,
+                    ]);
+                }
+            }
+        } elseif ($apply_to === 'collections') {
+            foreach ($collection_ids as $collection_id) {
+                $product_ids = db_query('SELECT product_id FROM collection_products WHERE collection_id = :collection_id', [':collection_id' => $collection_id])->fetchAll(PDO::FETCH_COLUMN);
+                foreach ($product_ids as $product_id) {
+                    db_query('INSERT INTO product_discounts (product_id, discount_id) VALUES (:product_id, :discount_id)', [
+                        ':product_id' => $product_id,
+                        ':discount_id' => $id,
+                    ]);
+                }
+            }
+        }
+        $_SESSION['flash_message'] = $is_sale ? 'Sale updated successfully.' : 'Discount updated successfully.';
+    } elseif ($action === 'delete' && $id) {
+        db_query('DELETE FROM discounts WHERE id = :id', [':id' => $id]);
+        $_SESSION['flash_message'] = 'Discount/Sale deleted successfully.';
+    }
+    header('Location: /admin/discounts.php');
+    exit;
+}
+
+// Fetch all discounts and sales
+$discounts = db_query('SELECT id, code, discount_percent, active, apply_to, is_sale, created_at FROM discounts ORDER BY created_at DESC')->fetchAll();
+
+// Fetch all products, product sets, and collections for the forms
+$products = db_query('SELECT id, title, price FROM products')->fetchAll();
+$product_sets = db_query('SELECT id, name FROM product_sets')->fetchAll();
+$collections = db_query('SELECT id, title FROM collections')->fetchAll();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Discounts and Sales</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<!-- Discount/Sale list -->
+<table>
+    <thead>
+        <tr>
+            <th>Code</th>
+            <th>Discount Percent</th>
+            <th>Active</th>
+            <th>Apply To</th>
+            <th>Type</th> <!-- New: Discount or Sale -->
+            <th>Created At</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($discounts as $discount): ?>
+        <tr>
+            <td><?= htmlspecialchars($discount['code']) ?></td>
+            <td><?= number_format((float)$discount['discount_percent'], 2) ?></td>
+            <td><?= $discount['active'] ? 'Yes' : 'No' ?></td>
+            <td><?= htmlspecialchars($discount['apply_to']) ?></td>
+            <td><?= $discount['is_sale'] ? 'Sale' : 'Discount' ?></td> <!-- New: Display type -->
+            <td><?= htmlspecialchars($discount['created_at']) ?></td>
+            <td>
+                <a href="/admin/discounts.php?action=edit&id=<?= $discount['id'] ?>">Edit</a> |
+                <form method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this discount/sale?');">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="id" value="<?= $discount['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<!-- Add/Edit form -->
+<?php
+$editDiscount = null;
+if (isset($_GET['action']) && $_GET['action'] === 'edit' && isset($_GET['id'])) {
+    $editDiscount = db_query('SELECT id, code, discount_percent, active, apply_to, is_sale FROM discounts WHERE id = :id', [':id' => $_GET['id']])->fetch();
+}
+?>
+
+<h2><?= $editDiscount ? 'Edit Discount/Sale' : 'Add New Discount/Sale' ?></h2>
+<form method="post">
+    <input type="hidden" name="action" value="<?= $editDiscount ? 'edit' : 'add' ?>">
+    <?php if ($editDiscount): ?>
+        <input type="hidden" name="id" value="<?= $editDiscount['id'] ?>">
+    <?php endif; ?>
+
+    <label for="code">Code:</label><br>
+    <input type="text" id="code" name="code" required value="<?= $editDiscount ? htmlspecialchars($editDiscount['code']) : '' ?>"><br><br>
+
+    <label for="discount_percent">Discount Percent:</label><br>
+    <input type="number" step="0.01" id="discount_percent" name="discount_percent" required value="<?= $editDiscount ? htmlspecialchars($editDiscount['discount_percent']) : '' ?>"><br><br>
+
+    <label for="active">Active:</label>
+    <input type="checkbox" id="active" name="active" <?= $editDiscount && $editDiscount['active'] ? 'checked' : '' ?>><br><br>
+
+    <label for="apply_to">Apply To:</label><br>
+    <select id="apply_to" name="apply_to">
+        <option value="all" <?= ($editDiscount && $editDiscount['apply_to'] === 'all') ? 'selected' : '' ?>>All Products</option>
+        <option value="products" <?= ($editDiscount && $editDiscount['apply_to'] === 'products') ? 'selected' : '' ?>>Specific Products</option>
+        <option value="sets" <?= ($editDiscount && $editDiscount['apply_to'] === 'sets') ? 'selected' : '' ?>>Product Sets</option>
+        <option value="collections" <?= ($editDiscount && $editDiscount['apply_to'] === 'collections') ? 'selected' : '' ?>>Collections</option>
+    </select><br><br>
+
+    <label for="is_sale">Is Sale:</label> <!-- New: Is Sale option -->
+    <input type="checkbox" id="is_sale" name="is_sale" <?= $editDiscount && $editDiscount['is_sale'] ? 'checked' : '' ?>><br><br>
+
+    <?php // Product selection ?>
+    <div id="product_selection" style="display:<?= ($editDiscount && $editDiscount['apply_to'] === 'products') || (!$editDiscount) ? 'block' : 'none' ?>;">
+        <label>Select Products:</label><br>
+        <?php foreach ($products as $product): ?>
+            <input type="checkbox" name="product_ids[]" value="<?= $product['id'] ?>" >
+            <?= htmlspecialchars($product['title']) ?><br>
+        <?php endforeach; ?>
+    </div>
+
+    <?php // Product set selection ?>
+    <div id="set_selection" style="display:<?= ($editDiscount && $editDiscount['apply_to'] === 'sets') ? 'block' : 'none' ?>;">
+        <label>Select Product Sets:</label><br>
+        <?php foreach ($product_sets as $set): ?>
+            <input type="checkbox" name="set_ids[]" value="<?= $set['id'] ?>">
+            <?= htmlspecialchars($set['name']) ?><br>
+        <?php endforeach; ?>
+    </div>
+
+    <?php // Collection selection ?>
+    <div id="collection_selection" style="display:<?= ($editDiscount && $editDiscount['apply_to'] === 'collections') ? 'block' : 'none' ?>;">
+        <label>Select Collections:</label><br>
+        <?php foreach ($collections as $collection): ?>
+            <input type="checkbox" name="collection_ids[]" value="<?= $collection['id'] ?>">
+            <?= htmlspecialchars($collection['title']) ?><br>
+        <?php endforeach; ?>
+    </div>
+
+    <button type="submit"><?= $editDiscount ? 'Update' : 'Add' ?> Discount/Sale</button>
+</form>
+
+<script>
+const applyToSelect = document.getElementById('apply_to');
+const productSelection = document.getElementById('product_selection');
+const setSelection = document.getElementById('set_selection');
+const collectionSelection = document.getElementById('collection_selection');
+
+applyToSelect.addEventListener('change', function() {
+    productSelection.style.display = (this.value === 'products') ? 'block' : 'none';
+    setSelection.style.display = (this.value === 'sets') ? 'block' : 'none';
+    collectionSelection.style.display = (this.value === 'collections') ? 'block' : 'none';
+});
+</script>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/discounts/index.php
+++ b/admin/discounts/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Discounts Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Discounts</h1>
+<p>Overview of available promotions.</p>
+<ul>
+  <li><a href="discounts.php">Discounts</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/editor/theme-settings.php
+++ b/admin/editor/theme-settings.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$themeId = db_query('SELECT id FROM themes WHERE active = 1 LIMIT 1')->fetchColumn();
+$schemaFile = THEME_PATH . '/settings-schema.json';
+$schema = is_file($schemaFile) ? json_decode(file_get_contents($schemaFile), true) : [];
+
+$pageTitle = 'Theme Settings';
+require __DIR__ . '/../components/header.php';
+?>
+<link rel="stylesheet" href="/admin/assets/admin.css">
+<h1>Theme Settings</h1>
+<div class="settings-wrapper">
+  <aside class="settings-menu">
+    <ul>
+      <?php foreach ($schema as $group => $fields): ?>
+        <li><a href="#<?= htmlspecialchars($group) ?>"><?= htmlspecialchars($group) ?></a></li>
+      <?php endforeach; ?>
+    </ul>
+  </aside>
+  <div class="settings-content">
+    <?php foreach ($schema as $group => $fields): ?>
+      <section id="<?= htmlspecialchars($group) ?>" class="settings-group">
+        <h2><?= htmlspecialchars($group) ?></h2>
+        <?php foreach ($fields as $key => $field):
+            $val = getSetting($key, $field['default'] ?? ''); ?>
+          <div class="setting-row">
+            <label><?= htmlspecialchars($field['label']) ?></label>
+            <?php switch($field['type']){
+              case 'color': ?>
+                <input type="color" class="setting-input" data-key="<?= $key ?>" value="<?= htmlspecialchars($val) ?>">
+              <?php break; case 'range': ?>
+                <input type="range" min="<?= $field['min'] ?>" max="<?= $field['max'] ?>" class="setting-input" data-key="<?= $key ?>" value="<?= htmlspecialchars($val) ?>">
+              <?php break; case 'checkbox': ?>
+                <input type="checkbox" class="setting-input" data-key="<?= $key ?>" <?= $val ? 'checked' : '' ?>>
+              <?php break; default: ?>
+                <input type="text" class="setting-input" data-key="<?= $key ?>" value="<?= htmlspecialchars($val) ?>">
+            <?php } ?>
+          </div>
+        <?php endforeach; ?>
+      </section>
+    <?php endforeach; ?>
+  </div>
+</div>
+<script>const CURRENT_THEME_ID = <?= (int)$themeId ?>;</script>
+<script src="/admin/assets/theme-settings.js"></script>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/marketing/index.php
+++ b/admin/marketing/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Marketing Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Marketing</h1>
+<p>Campaign and analytics tools.</p>
+<ul>
+  <li><a href="marketing.php">Marketing Dashboard</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/orders/index.php
+++ b/admin/orders/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Orders Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Orders</h1>
+<p>Access order management tools below.</p>
+<ul>
+  <li><a href="orders.php">Orders</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/orders/orders.php
+++ b/admin/orders/orders.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Orders';
+
+// Handle form submissions for updating order status or deleting orders
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $id = $_POST['id'] ?? null;
+    $status = $_POST['status'] ?? '';
+
+    if ($action === 'update_status' && $id && $status) {
+        db_query('UPDATE orders SET status = :status WHERE id = :id', [
+            ':status' => $status,
+            ':id' => $id,
+        ]);
+        $_SESSION['flash_message'] = 'Order status updated successfully.';
+    } elseif ($action === 'delete' && $id) {
+        db_query('DELETE FROM orders WHERE id = :id', [':id' => $id]);
+        $_SESSION['flash_message'] = 'Order deleted successfully.';
+    }
+    header('Location: /admin/orders.php');
+    exit;
+}
+
+// Fetch all orders with customer info
+$orders = db_query('
+    SELECT o.id, o.status, o.total_amount, o.created_at, c.first_name, c.last_name
+    FROM orders o
+    LEFT JOIN customers c ON o.customer_id = c.id
+    ORDER BY o.created_at DESC
+')->fetchAll();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Orders</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<!-- Orders list -->
+<table>
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Customer</th>
+            <th>Total</th>
+            <th>Status</th>
+            <th>Created At</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($orders as $order): ?>
+        <tr>
+            <td><?= $order['id'] ?></td>
+            <td><?= htmlspecialchars($order['first_name'] . ' ' . $order['last_name']) ?></td>
+            <td>$<?= number_format($order['total_amount'], 2) ?></td>
+            <td><?= htmlspecialchars($order['status']) ?></td>
+            <td><?= htmlspecialchars($order['created_at']) ?></td>
+            <td>
+                <form method="post" style="display:inline;">
+                    <input type="hidden" name="action" value="update_status">
+                    <input type="hidden" name="id" value="<?= $order['id'] ?>">
+                    <select name="status" onchange="this.form.submit()">
+                        <option value="pending" <?= $order['status'] === 'pending' ? 'selected' : '' ?>>Pending</option>
+                        <option value="processing" <?= $order['status'] === 'processing' ? 'selected' : '' ?>>Processing</option>
+                        <option value="completed" <?= $order['status'] === 'completed' ? 'selected' : '' ?>>Completed</option>
+                        <option value="cancelled" <?= $order['status'] === 'cancelled' ? 'selected' : '' ?>>Cancelled</option>
+                    </select>
+                </form>
+                <form method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this order?');">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="id" value="<?= $order['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/pages/index.php
+++ b/admin/pages/index.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Pages Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Pages</h1>
+<p>Manage site pages and templates.</p>
+<ul>
+  <li><a href="pages.php">Pages</a></li>
+  <li><a href="templates.php">Page Templates</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/pages/pages.php
+++ b/admin/pages/pages.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Pages';
+
+// Handle form submissions for adding/editing/deleting pages
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $id = $_POST['id'] ?? null;
+    $title = trim($_POST['title'] ?? '');
+    $slug = trim($_POST['slug'] ?? '');
+    $content = trim($_POST['content'] ?? '');
+    $layout  = trim($_POST['layout'] ?? '{}');
+    $headCode = trim($_POST['head_code'] ?? '');
+    $bodyStartCode = trim($_POST['body_start_code'] ?? '');
+    $bodyEndCode = trim($_POST['body_end_code'] ?? '');
+    $cssCode = trim($_POST['css_code'] ?? '');
+    $jsCode = trim($_POST['js_code'] ?? '');
+    $userId = $_SESSION['user_id'];
+
+    if ($action === 'add' && $title && $slug) {
+        db_query('INSERT INTO pages (title, slug, content, layout, layout_draft, layout_published, head_code, body_start_code, body_end_code, css_code, js_code, is_published, version, created_at) VALUES (:title, :slug, :content, :layout, :layout, :layout, :head, :bstart, :bend, :css, :js, 1, 1, NOW())', [
+            ':title' => $title,
+            ':slug' => $slug,
+            ':content' => $content,
+            ':layout' => $layout,
+            ':head' => $headCode,
+            ':bstart' => $bodyStartCode,
+            ':bend' => $bodyEndCode,
+            ':css' => $cssCode,
+            ':js' => $jsCode,
+        ]);
+        $pageId = (int)db()->lastInsertId();
+        db_query('INSERT INTO page_versions (page_id, version, saved_by, layout_snapshot) VALUES (:pid, 1, :uid, :snap)', [
+            ':pid' => $pageId,
+            ':uid' => $userId,
+            ':snap' => $layout,
+        ]);
+        $_SESSION['flash_message'] = 'Page added successfully.';
+    } elseif ($action === 'edit' && $id && $title && $slug) {
+        $page = db_query('SELECT version FROM pages WHERE id = :id', [':id' => $id])->fetch();
+        $newVersion = ($page['version'] ?? 0) + 1;
+        db_query('UPDATE pages SET title = :title, slug = :slug, content = :content, layout_draft = :layout, layout_published = :layout, head_code = :head, body_start_code = :bstart, body_end_code = :bend, css_code = :css, js_code = :js, is_published = 1, version = :ver WHERE id = :id', [
+            ':title' => $title,
+            ':slug' => $slug,
+            ':content' => $content,
+            ':layout' => $layout,
+            ':head' => $headCode,
+            ':bstart' => $bodyStartCode,
+            ':bend' => $bodyEndCode,
+            ':css' => $cssCode,
+            ':js' => $jsCode,
+            ':ver' => $newVersion,
+            ':id' => $id,
+        ]);
+        db_query('INSERT INTO page_versions (page_id, version, saved_by, layout_snapshot) VALUES (:pid, :ver, :uid, :snap)', [
+            ':pid' => $id,
+            ':ver' => $newVersion,
+            ':uid' => $userId,
+            ':snap' => $layout,
+        ]);
+        $_SESSION['flash_message'] = 'Page updated successfully.';
+    } elseif ($action === 'delete' && $id) {
+        db_query('DELETE FROM pages WHERE id = :id', [':id' => $id]);
+        $_SESSION['flash_message'] = 'Page deleted successfully.';
+    }
+    header('Location: /admin/pages.php');
+    exit;
+}
+
+// Fetch all pages
+$pages = db_query('SELECT id, title, slug, created_at, version, is_published FROM pages ORDER BY created_at DESC')->fetchAll();
+
+require __DIR__ . '/components/header.php';
+?>
+
+<h1>Pages</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<!-- Pages list -->
+<table>
+    <thead>
+        <tr>
+            <th>Title</th>
+            <th>Slug</th>
+            <th>Version</th>
+            <th>Status</th>
+            <th>Created At</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($pages as $page): ?>
+        <tr>
+            <td><?= htmlspecialchars($page['title']) ?></td>
+            <td><?= htmlspecialchars($page['slug']) ?></td>
+            <td><?= (int)$page['version'] ?></td>
+            <td><?= $page['is_published'] ? 'Published' : 'Draft' ?></td>
+            <td><?= htmlspecialchars($page['created_at']) ?></td>
+            <td>
+                <a href="/admin/pages.php?action=edit&id=<?= $page['id'] ?>">Edit</a> |
+                <form method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this page?');">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="id" value="<?= $page['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<!-- Add/Edit form -->
+<?php
+$editPage = null;
+if (isset($_GET['action']) && $_GET['action'] === 'edit' && isset($_GET['id'])) {
+    $editPage = db_query('SELECT id, title, slug, content, layout_draft, layout_published, head_code, body_start_code, body_end_code, css_code, js_code, version FROM pages WHERE id = :id', [':id' => $_GET['id']])->fetch();
+}
+?>
+
+<h2><?= $editPage ? 'Edit Page' : 'Add New Page' ?></h2>
+<form method="post">
+    <input type="hidden" name="action" value="<?= $editPage ? 'edit' : 'add' ?>">
+    <?php if ($editPage): ?>
+        <input type="hidden" name="id" value="<?= $editPage['id'] ?>">
+    <?php endif; ?>
+    <label for="title">Title:</label><br>
+    <input type="text" id="title" name="title" required value="<?= $editPage ? htmlspecialchars($editPage['title']) : '' ?>"><br><br>
+    <label for="slug">Slug:</label><br>
+    <input type="text" id="slug" name="slug" required value="<?= $editPage ? htmlspecialchars($editPage['slug']) : '' ?>"><br><br>
+    <label for="content">Content:</label><br>
+    <textarea id="content" name="content" rows="6"><?= $editPage ? htmlspecialchars($editPage['content']) : '' ?></textarea><br><br>
+    <label for="layout">Layout JSON:</label><br>
+    <textarea id="layout" name="layout" rows="10"><?= $editPage ? htmlspecialchars($editPage['layout_draft'] ?? $editPage['layout_published']) : '{}' ?></textarea><br><br>
+    <label for="head_code">Head Code:</label><br>
+    <textarea id="head_code" name="head_code" rows="4"><?= $editPage ? htmlspecialchars($editPage['head_code'] ?? '') : '' ?></textarea><br><br>
+    <label for="body_start_code">Body Start Code:</label><br>
+    <textarea id="body_start_code" name="body_start_code" rows="4"><?= $editPage ? htmlspecialchars($editPage['body_start_code'] ?? '') : '' ?></textarea><br><br>
+    <label for="body_end_code">Body End Code:</label><br>
+    <textarea id="body_end_code" name="body_end_code" rows="4"><?= $editPage ? htmlspecialchars($editPage['body_end_code'] ?? '') : '' ?></textarea><br><br>
+    <label for="css_code">Page CSS:</label><br>
+    <textarea id="css_code" name="css_code" rows="4"><?= $editPage ? htmlspecialchars($editPage['css_code'] ?? '') : '' ?></textarea><br><br>
+    <label for="js_code">Page JS:</label><br>
+    <textarea id="js_code" name="js_code" rows="4"><?= $editPage ? htmlspecialchars($editPage['js_code'] ?? '') : '' ?></textarea><br><br>
+    <button type="submit"><?= $editPage ? 'Update' : 'Add' ?> Page</button>
+</form>
+
+<h3>Preview</h3>
+<?php if ($editPage): ?>
+<iframe src="/page/<?= htmlspecialchars($editPage['slug']) ?>" style="width:100%;height:400px;border:1px solid #ccc;"></iframe>
+<?php endif; ?>
+
+<?php
+require __DIR__ . '/components/footer.php';
+?>

--- a/admin/pages/templates.php
+++ b/admin/pages/templates.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Page Templates';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'delete') {
+        $id = intval($_POST['id']);
+        $stmt = $pdo->prepare('DELETE FROM page_templates WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+}
+
+$templates = $pdo->query('SELECT * FROM page_templates ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+include __DIR__ . '/components/header.php';
+?>
+<h1>Page Templates</h1>
+<table class="table">
+    <tr><th>ID</th><th>Name</th><th>Type</th><th>Actions</th></tr>
+    <?php foreach ($templates as $tpl): ?>
+    <tr>
+        <td><?= htmlspecialchars($tpl['id']) ?></td>
+        <td><?= htmlspecialchars($tpl['name']) ?></td>
+        <td><?= htmlspecialchars($tpl['type']) ?></td>
+        <td>
+            <form method="post" style="display:inline">
+                <input type="hidden" name="id" value="<?= $tpl['id'] ?>">
+                <input type="hidden" name="action" value="delete">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete template?')">Delete</button>
+            </form>
+        </td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+<?php include __DIR__ . '/components/footer.php'; ?>

--- a/admin/plugins/index.php
+++ b/admin/plugins/index.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Plugins Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Plugins</h1>
+<p>Manage installed plugins.</p>
+<ul>
+  <li><a href="plugins.php">Plugins</a></li>
+  <li><a href="plugins_add.php">Add Plugin</a></li>
+  <li><a href="plugins_delete.php">Delete Plugin</a></li>
+  <li><a href="plugins_toggle.php">Toggle Plugin</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/plugins/plugins.php
+++ b/admin/plugins/plugins.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+// Check if user is logged in and has admin role
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Plugin Management';
+
+// Fetch installed plugins from database or config
+$plugins = db_query('SELECT * FROM plugins')->fetchAll();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Plugin Management</h1>
+
+<table border="1" cellpadding="5" cellspacing="0" style="width: 100%;">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Version</th>
+            <th>Status</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($plugins as $plugin): ?>
+        <tr>
+            <td><?= htmlspecialchars($plugin['name']) ?></td>
+            <td><?= htmlspecialchars($plugin['description']) ?></td>
+            <td><?= htmlspecialchars($plugin['version']) ?></td>
+            <td><?= $plugin['enabled'] ? 'Enabled' : 'Disabled' ?></td>
+            <td>
+                <?php if ($plugin['enabled']): ?>
+                    <a href="plugins_toggle.php?id=<?= $plugin['id'] ?>&action=disable">Disable</a>
+                <?php else: ?>
+                    <a href="plugins_toggle.php?id=<?= $plugin['id'] ?>&action=enable">Enable</a>
+                <?php endif; ?>
+                | <a href="plugins_delete.php?id=<?= $plugin['id'] ?>" onclick="return confirm('Are you sure you want to delete this plugin?');">Delete</a>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<h2>Add New Plugin</h2>
+<form method="post" action="plugins_add.php" enctype="multipart/form-data">
+    <label for="plugin_file">Plugin ZIP File:</label><br>
+    <input type="file" id="plugin_file" name="plugin_file" accept=".zip" required><br><br>
+    <button type="submit">Upload and Install</button>
+</form>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/plugins/plugins_add.php
+++ b/admin/plugins/plugins_add.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in and has admin role
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['plugin_file'])) {
+    $file = $_FILES['plugin_file'];
+
+    if ($file['error'] === UPLOAD_ERR_OK) {
+        $tmpName = $file['tmp_name'];
+        $zip = new ZipArchive();
+        if ($zip->open($tmpName) === true) {
+            // Extract to plugins directory
+            $pluginsDir = __DIR__ . '/../plugins/';
+            if (!is_dir($pluginsDir)) {
+                mkdir($pluginsDir, 0755, true);
+            }
+
+            // Extract to a temp folder to read plugin info
+            $tempDir = sys_get_temp_dir() . '/plugin_' . uniqid();
+            mkdir($tempDir, 0755, true);
+            $zip->extractTo($tempDir);
+            $zip->close();
+
+            // Read plugin info from plugin.json
+            $pluginJsonPath = $tempDir . '/plugin.json';
+            if (file_exists($pluginJsonPath)) {
+                $pluginInfo = json_decode(file_get_contents($pluginJsonPath), true);
+                if ($pluginInfo && isset($pluginInfo['name'])) {
+                    $pluginName = $pluginInfo['name'];
+                    $pluginDir = $pluginsDir . $pluginName;
+
+                    // Move extracted files to plugins directory
+                    if (is_dir($pluginDir)) {
+                        // Remove existing plugin directory
+                        $it = new RecursiveDirectoryIterator($pluginDir, RecursiveDirectoryIterator::SKIP_DOTS);
+                        $files = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
+                        foreach ($files as $file) {
+                            if ($file->isDir()) {
+                                rmdir($file->getRealPath());
+                            } else {
+                                unlink($file->getRealPath());
+                            }
+                        }
+                        rmdir($pluginDir);
+                    }
+                    rename($tempDir, $pluginDir);
+
+                    // Insert plugin info into database
+                    db_query('INSERT INTO plugins (name, description, version, enabled) VALUES (:name, :description, :version, 0)', [
+                        ':name' => $pluginName,
+                        ':description' => $pluginInfo['description'] ?? '',
+                        ':version' => $pluginInfo['version'] ?? '1.0.0',
+                    ]);
+
+                    $_SESSION['flash_message'] = 'Plugin installed successfully.';
+                } else {
+                    $_SESSION['flash_message'] = 'Invalid plugin.json file.';
+                    // Cleanup temp dir
+                    rmdir($tempDir);
+                }
+            } else {
+                $_SESSION['flash_message'] = 'plugin.json file not found in ZIP.';
+                // Cleanup temp dir
+                rmdir($tempDir);
+            }
+        } else {
+            $_SESSION['flash_message'] = 'Failed to open ZIP file.';
+        }
+    } else {
+        $_SESSION['flash_message'] = 'File upload error.';
+    }
+} else {
+    $_SESSION['flash_message'] = 'Invalid request.';
+}
+
+header('Location: /admin/plugins.php');
+exit;
+?>

--- a/admin/plugins/plugins_delete.php
+++ b/admin/plugins/plugins_delete.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+// Check if user is logged in and has admin role
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$id = intval($_GET['id'] ?? 0);
+
+if ($id > 0) {
+    // Fetch plugin info
+    $plugin = db_query('SELECT * FROM plugins WHERE id = :id', [':id' => $id])->fetch();
+
+    if ($plugin) {
+        // Delete plugin files - assuming plugins are stored in /plugins/{plugin_name}
+        $pluginDir = __DIR__ . '/../plugins/' . $plugin['name'];
+        if (is_dir($pluginDir)) {
+            // Recursively delete directory
+            $it = new RecursiveDirectoryIterator($pluginDir, RecursiveDirectoryIterator::SKIP_DOTS);
+            $files = new RecursiveIteratorIterator($it, RecursiveIteratorIterator::CHILD_FIRST);
+            foreach ($files as $file) {
+                if ($file->isDir()) {
+                    rmdir($file->getRealPath());
+                } else {
+                    unlink($file->getRealPath());
+                }
+            }
+            rmdir($pluginDir);
+        }
+
+        // Delete plugin record from database
+        db_query('DELETE FROM plugins WHERE id = :id', [':id' => $id]);
+    }
+}
+
+header('Location: /admin/plugins.php');
+exit;
+?>

--- a/admin/plugins/plugins_toggle.php
+++ b/admin/plugins/plugins_toggle.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+// Check if user is logged in and has admin role
+if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'admin') {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$id = intval($_GET['id'] ?? 0);
+$action = $_GET['action'] ?? '';
+
+if ($id > 0 && in_array($action, ['enable', 'disable'])) {
+    $enabled = $action === 'enable' ? 1 : 0;
+    db_query('UPDATE plugins SET enabled = :enabled WHERE id = :id', [
+        ':enabled' => $enabled,
+        ':id' => $id,
+    ]);
+}
+
+header('Location: /admin/plugins.php');
+exit;
+?>

--- a/admin/products/collections.php
+++ b/admin/products/collections.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+  header('Location: /backend/auth/login.php');
+  exit;
+}
+
+$page_title = "Collections";
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title><?= htmlspecialchars($page_title) ?></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/admin/assets/css/admin.css" rel="stylesheet" onerror="console.warn('admin.css not found')">
+  <script src="/admin/assets/js/collections.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+</head>
+<body>
+  <?php include '../components/header.php'; ?>
+
+   <div class="container py-4 d-flex flex-column gap-3">
+  <!-- Each child will stack vertically with spacing -->
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h2>Collections</h2>
+      <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#modal-collection">+ Create Collection</button>
+    </div>
+    <div id="collectionsTable">Loading...</div>
+  </div>
+
+  <?php include '../modals/modal-collection.php'; ?>
+  <?php include '../components/footer.php'; ?>
+</body>
+</html>

--- a/admin/products/index.php
+++ b/admin/products/index.php
@@ -1,0 +1,15 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Products Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Products</h1>
+<p>Manage your catalog from here.</p>
+<ul>
+  <li><a href="products.php">Products</a></li>
+  <li><a href="collections.php">Collections</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/products/products.php
+++ b/admin/products/products.php
@@ -1,0 +1,126 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$page_title = "Products";
+$cache_bust = filemtime(__DIR__ . '/../../admin/assets/js/products.js');
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title><?= htmlspecialchars($page_title) ?></title>
+
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/admin/assets/css/admin.css?v=<?= $cache_bust ?>" rel="stylesheet" onerror="console.warn('admin.css not found')">
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" defer></script>
+  <script src="/admin/assets/js/products.js?v=<?= $cache_bust ?>" defer></script>
+</head>
+<body>
+  <?php include '../components/header.php'; ?>
+
+<div class="container py-4 d-flex flex-column gap-3">
+  <!-- Section Title -->
+  <div class="mb-3 d-flex justify-content-between align-items-center">
+    <h2 class="fw-bold">🛍️ Product Manager</h2>
+    <div>
+      <button id="csvExportBtn" class="btn btn-outline-primary me-2" disabled>Export CSV</button>
+      <button class="btn btn-outline-primary me-2" data-bs-toggle="modal" data-bs-target="#modal-import-product">
+        📥 Import Catalog
+      </button>
+      <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#modal-product">
+        ➕ Add Product
+      </button>
+    </div>
+  </div>
+
+  <!-- Filters -->
+  <form id="product-filter" class="row row-cols-lg-auto g-2 align-items-end mb-3">
+    <div class="col-12">
+      <input type="text" name="q" class="form-control" placeholder="Search title or tags">
+    </div>
+    <div class="col-12">
+      <input type="text" name="vendor" class="form-control" placeholder="Vendor">
+    </div>
+    <div class="col-12">
+      <input type="text" name="type" class="form-control" placeholder="Type">
+    </div>
+    <div class="col-12">
+      <input type="number" name="min_price" class="form-control" step="0.01" placeholder="Min Price">
+    </div>
+    <div class="col-12">
+      <input type="number" name="max_price" class="form-control" step="0.01" placeholder="Max Price">
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-outline-primary">Filter</button>
+    </div>
+  </form>
+
+  <!-- Product Table -->
+  <div id="productTable" class="table-responsive"></div>
+  <div id="productCount" class="text-muted mb-3"></div>
+</div>
+
+  <!-- Product Modals -->
+  <?php include '../modals/modal-product.php'; ?>
+  <?php include '../modals/modal-product-edit.php'; ?>
+
+  <!-- Import Modal -->
+  <div class="modal fade" id="modal-import-product" tabindex="-1">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+      <div class="modal-content">
+        <form id="product-import-form">
+          <div class="modal-header">
+            <h5 class="modal-title">📥 Import Product Catalog</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="csvFile" class="form-label">Upload CSV File</label>
+              <input type="file" name="csv" id="csvFile" class="form-control" accept=".csv" required>
+            </div>
+
+            <div class="mb-3">
+              <label class="form-label">Import Mode</label>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="mode" value="append" id="mode-append" checked>
+                <label class="form-check-label" for="mode-append">Append – Keep existing and add new</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="mode" value="overwrite" id="mode-overwrite">
+                <label class="form-check-label" for="mode-overwrite">Overwrite – Update existing SKUs if matched</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="radio" name="mode" value="replace" id="mode-replace">
+                <label class="form-check-label text-danger" for="mode-replace">Replace – Delete everything and upload fresh</label>
+              </div>
+            </div>
+
+            <div class="d-none" id="mapping-section">
+              <h6>Map Your CSV Columns</h6>
+              <table class="table table-sm table-bordered mt-2" id="mappingTable"></table>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="submit" class="btn btn-primary">📥 Import Now</button>
+            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  
+  <?php include '../modals/modal-collection.php'; ?>
+  <?php include '../components/footer.php'; ?>
+</body>
+</html>

--- a/admin/reports/index.php
+++ b/admin/reports/index.php
@@ -1,0 +1,14 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Reports Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Reports</h1>
+<p>Summary of analytics reports.</p>
+<ul>
+  <li><a href="reports.php">Reports</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/reports/reports.php
+++ b/admin/reports/reports.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Reports';
+
+// Example report: Sales by product
+$salesReport = db_query('
+    SELECT p.title, SUM(oi.quantity) AS total_quantity, SUM(oi.price * oi.quantity) AS total_sales
+    FROM order_items oi
+    JOIN products p ON oi.product_id = p.id
+    GROUP BY p.title
+    ORDER BY total_sales DESC
+')->fetchAll();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Reports</h1>
+
+<h2>Sales by Product</h2>
+<table>
+    <thead>
+        <tr>
+            <th>Product</th>
+            <th>Total Quantity Sold</th>
+            <th>Total Sales</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($salesReport as $row): ?>
+        <tr>
+            <td><?= htmlspecialchars($row['title']) ?></td>
+            <td><?= (int)$row['total_quantity'] ?></td>
+            <td>$<?= number_format($row['total_sales'], 2) ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/settings/checkout_settings.php
+++ b/admin/settings/checkout_settings.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$file = THEME_PATH . '/config/checkout_success.json';
+$data = is_file($file) ? json_decode(file_get_contents($file), true) : [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $json = $_POST['json'] ?? '';
+    if ($json) {
+        file_put_contents($file, $json);
+        $_SESSION['flash_message'] = 'Checkout success settings saved.';
+    }
+    header('Location: /admin/checkout_settings.php');
+    exit;
+}
+
+$pageTitle = 'Checkout Success Settings';
+include __DIR__ . '/components/header.php';
+?>
+<h1>Checkout Success Settings</h1>
+<?php if (!empty($_SESSION['flash_message'])): ?>
+<div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+<?php unset($_SESSION['flash_message']); endif; ?>
+<form method="post">
+    <textarea name="json" rows="20" style="width:100%;"><?= htmlspecialchars(json_encode($data, JSON_PRETTY_PRINT)) ?></textarea><br>
+    <button class="btn btn-primary">Save</button>
+</form>
+<?php include __DIR__ . '/components/footer.php'; ?>

--- a/admin/settings/global_sections.php
+++ b/admin/settings/global_sections.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Global Sections';
+$current = null;
+if (isset($_GET['edit'])) {
+    $id = intval($_GET['edit']);
+    $stmt = db()->prepare('SELECT * FROM global_sections WHERE id=?');
+    $stmt->execute([$id]);
+    $current = $stmt->fetch(PDO::FETCH_ASSOC);
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['delete'])) {
+        $id = intval($_POST['id']);
+        db_query('DELETE FROM global_sections WHERE id = ?', [$id]);
+    } elseif (isset($_POST['id'])) {
+        // update existing
+        $id = intval($_POST['id']);
+        $handle = slugify(trim($_POST['handle']));
+        $title = trim($_POST['title']);
+        $type = trim($_POST['type']);
+        $json = $_POST['section_json'];
+        $pages = trim($_POST['used_on_pages']);
+        db_query('UPDATE global_sections SET handle=?, title=?, type=?, section_json=?, used_on_pages=? WHERE id=?', [$handle, $title, $type, $json, $pages, $id]);
+    } elseif (isset($_POST['handle'], $_POST['title'], $_POST['type'], $_POST['section_json'])) {
+        $handle = slugify(trim($_POST['handle']));
+        $title = trim($_POST['title']);
+        $type = trim($_POST['type']);
+        $json = $_POST['section_json'];
+        $pages = trim($_POST['used_on_pages'] ?? '');
+        db_query('INSERT INTO global_sections (handle, title, type, section_json, used_on_pages) VALUES (?, ?, ?, ?, ?)', [$handle, $title, $type, $json, $pages]);
+    }
+}
+
+$sections = db_query('SELECT * FROM global_sections ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+include __DIR__ . '/components/header.php';
+?>
+<h1>Global Sections</h1>
+<form method="post" class="mb-3">
+    <input type="hidden" name="id" value="<?= $current['id'] ?? '' ?>">
+    <input type="text" name="handle" placeholder="Handle" required value="<?= htmlspecialchars($current['handle'] ?? '') ?>">
+    <input type="text" name="title" placeholder="Title" required value="<?= htmlspecialchars($current['title'] ?? '') ?>">
+    <input type="text" name="type" placeholder="Section Type" required value="<?= htmlspecialchars($current['type'] ?? '') ?>">
+    <input type="text" name="used_on_pages" placeholder="Page slugs (comma separated)" value="<?= htmlspecialchars($current['used_on_pages'] ?? '') ?>">
+    <textarea name="section_json" placeholder='{"settings":{}}' required><?= htmlspecialchars($current['section_json'] ?? '') ?></textarea>
+    <button class="btn btn-primary"><?= $current ? 'Update' : 'Create' ?></button>
+</form>
+<table class="table">
+<tr><th>ID</th><th>Handle</th><th>Type</th><th>Pages</th><th>Actions</th></tr>
+<?php foreach ($sections as $s): ?>
+<tr>
+<td><?= htmlspecialchars($s['id']) ?></td>
+<td><?= htmlspecialchars($s['handle']) ?></td>
+<td><?= htmlspecialchars($s['type']) ?></td>
+<td><?= htmlspecialchars($s['used_on_pages']) ?></td>
+<td>
+<a class="btn btn-sm btn-primary" href="?edit=<?= $s['id'] ?>">Edit</a>
+<form method="post" style="display:inline">
+    <input type="hidden" name="id" value="<?= $s['id'] ?>">
+    <button class="btn btn-sm btn-danger" name="delete" value="1" onclick="return confirm('Delete?')">Delete</button>
+</form>
+</td>
+</tr>
+<?php endforeach; ?>
+</table>
+<?php include __DIR__ . '/components/footer.php'; ?>

--- a/admin/settings/index.php
+++ b/admin/settings/index.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Settings Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Settings</h1>
+<p>Configure store preferences.</p>
+<ul>
+  <li><a href="settings.php">Settings</a></li>
+  <li><a href="checkout_settings.php">Checkout Success</a></li>
+  <li><a href="presets.php">Section Presets</a></li>
+  <li><a href="global_sections.php">Global Sections</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/settings/presets.php
+++ b/admin/settings/presets.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Section Presets';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'delete') {
+        $id = intval($_POST['id']);
+        $stmt = $pdo->prepare('DELETE FROM section_presets WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+}
+
+$presets = $pdo->query('SELECT * FROM section_presets ORDER BY created_at DESC')->fetchAll(PDO::FETCH_ASSOC);
+include __DIR__ . '/components/header.php';
+?>
+<h1>Section Presets</h1>
+<table class="table">
+    <tr><th>ID</th><th>Name</th><th>Type</th><th>Actions</th></tr>
+    <?php foreach ($presets as $preset): ?>
+    <tr>
+        <td><?= htmlspecialchars($preset['id']) ?></td>
+        <td><?= htmlspecialchars($preset['name']) ?></td>
+        <td><?= htmlspecialchars($preset['type']) ?></td>
+        <td>
+            <form method="post" style="display:inline">
+                <input type="hidden" name="id" value="<?= $preset['id'] ?>">
+                <input type="hidden" name="action" value="delete">
+                <button class="btn btn-sm btn-danger" onclick="return confirm('Delete preset?')">Delete</button>
+            </form>
+        </td>
+    </tr>
+    <?php endforeach; ?>
+</table>
+<?php include __DIR__ . '/components/footer.php'; ?>

--- a/admin/settings/settings.php
+++ b/admin/settings/settings.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Settings';
+
+// Handle form submission to update settings
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['save_delivery_settings'])) {
+        $shiprocketApiKey = trim($_POST['shiprocket_api_key'] ?? '');
+        $shiprocketApiSecret = trim($_POST['shiprocket_api_secret'] ?? '');
+        $enableShiprocket = isset($_POST['enable_shiprocket']) ? 1 : 0;
+
+        $delhiveryApiKey = trim($_POST['delhivery_api_key'] ?? '');
+        $delhiveryApiSecret = trim($_POST['delhivery_api_secret'] ?? '');
+        $enableDelhivery = isset($_POST['enable_delhivery']) ? 1 : 0;
+
+        $ekartApiKey = trim($_POST['ekart_api_key'] ?? '');
+        $ekartApiSecret = trim($_POST['ekart_api_secret'] ?? '');
+        $enableEkart = isset($_POST['enable_ekart']) ? 1 : 0;
+
+        db_query('UPDATE settings SET shiprocket_api_key = :shiprocket_api_key, shiprocket_api_secret = :shiprocket_api_secret, enable_shiprocket = :enable_shiprocket, delhivery_api_key = :delhivery_api_key, delhivery_api_secret = :delhivery_api_secret, enable_delhivery = :enable_delhivery, ekart_api_key = :ekart_api_key, ekart_api_secret = :ekart_api_secret, enable_ekart = :enable_ekart WHERE id = 1', [
+            ':shiprocket_api_key' => $shiprocketApiKey,
+            ':shiprocket_api_secret' => $shiprocketApiSecret,
+            ':enable_shiprocket' => $enableShiprocket,
+            ':delhivery_api_key' => $delhiveryApiKey,
+            ':delhivery_api_secret' => $delhiveryApiSecret,
+            ':enable_delhivery' => $enableDelhivery,
+            ':ekart_api_key' => $ekartApiKey,
+            ':ekart_api_secret' => $ekartApiSecret,
+            ':enable_ekart' => $enableEkart,
+        ]);
+        $_SESSION['flash_message'] = 'Delivery partner settings updated successfully.';
+        header('Location: /admin/settings.php');
+        exit;
+    }
+
+    $siteName = trim($_POST['site_name'] ?? '');
+    $siteEmail = trim($_POST['site_email'] ?? '');
+    $storePassword = trim($_POST['store_password'] ?? '');
+    $storePasswordEnabled = isset($_POST['store_password_enabled']) ? 1 : 0;
+
+    $enableFacebookPixel = isset($_POST['enable_facebook_pixel']) ? 1 : 0;
+    $facebookPixelId = trim($_POST['facebook_pixel_id'] ?? '');
+    $enableGoogleAnalytics = isset($_POST['enable_google_analytics']) ? 1 : 0;
+    $googleAnalyticsId = trim($_POST['google_analytics_id'] ?? '');
+    $enableSnapchatPixel = isset($_POST['enable_snapchat_pixel']) ? 1 : 0;
+    $snapchatPixelId = trim($_POST['snapchat_pixel_id'] ?? '');
+
+    if ($siteName && filter_var($siteEmail, FILTER_VALIDATE_EMAIL)) {
+        if ($storePassword !== '') {
+            // Hash the password before storing
+            $hashedPassword = password_hash($storePassword, PASSWORD_DEFAULT);
+            db_query('UPDATE settings SET site_name = :site_name, site_email = :site_email, store_password = :store_password, store_password_enabled = :store_password_enabled, enable_facebook_pixel = :enable_facebook_pixel, facebook_pixel_id = :facebook_pixel_id, enable_google_analytics = :enable_google_analytics, google_analytics_id = :google_analytics_id, enable_snapchat_pixel = :enable_snapchat_pixel, snapchat_pixel_id = :snapchat_pixel_id WHERE id = 1', [
+                ':site_name' => $siteName,
+                ':site_email' => $siteEmail,
+                ':store_password' => $hashedPassword,
+                ':store_password_enabled' => $storePasswordEnabled,
+                ':enable_facebook_pixel' => $enableFacebookPixel,
+                ':facebook_pixel_id' => $facebookPixelId,
+                ':enable_google_analytics' => $enableGoogleAnalytics,
+                ':google_analytics_id' => $googleAnalyticsId,
+                ':enable_snapchat_pixel' => $enableSnapchatPixel,
+                ':snapchat_pixel_id' => $snapchatPixelId,
+            ]);
+        } else {
+            db_query('UPDATE settings SET site_name = :site_name, site_email = :site_email, store_password_enabled = :store_password_enabled, enable_facebook_pixel = :enable_facebook_pixel, facebook_pixel_id = :facebook_pixel_id, enable_google_analytics = :enable_google_analytics, google_analytics_id = :google_analytics_id, enable_snapchat_pixel = :enable_snapchat_pixel, snapchat_pixel_id = :snapchat_pixel_id WHERE id = 1', [
+                ':site_name' => $siteName,
+                ':site_email' => $siteEmail,
+                ':store_password_enabled' => $storePasswordEnabled,
+                ':enable_facebook_pixel' => $enableFacebookPixel,
+                ':facebook_pixel_id' => $facebookPixelId,
+                ':enable_google_analytics' => $enableGoogleAnalytics,
+                ':google_analytics_id' => $googleAnalyticsId,
+                ':enable_snapchat_pixel' => $enableSnapchatPixel,
+                ':snapchat_pixel_id' => $snapchatPixelId,
+            ]);
+        }
+        $_SESSION['flash_message'] = 'Settings updated successfully.';
+    } else {
+        $_SESSION['flash_message'] = 'Please provide valid site name and email.';
+    }
+    header('Location: /admin/settings.php');
+    exit;
+}
+
+$settings = db_query('SELECT site_name, site_email, store_password, store_password_enabled, enable_facebook_pixel, facebook_pixel_id, enable_google_analytics, google_analytics_id, enable_snapchat_pixel, snapchat_pixel_id FROM settings WHERE id = 1')->fetch();
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h2>Delivery Partner Integrations</h2>
+<form method="post" action="settings.php">
+    <h3>Shiprocket</h3>
+    <label for="shiprocket_api_key">API Key:</label><br>
+    <input type="text" id="shiprocket_api_key" name="shiprocket_api_key" value="<?= htmlspecialchars($settings['shiprocket_api_key'] ?? '') ?>"><br>
+    <label for="shiprocket_api_secret">API Secret:</label><br>
+    <input type="text" id="shiprocket_api_secret" name="shiprocket_api_secret" value="<?= htmlspecialchars($settings['shiprocket_api_secret'] ?? '') ?>"><br>
+    <label><input type="checkbox" name="enable_shiprocket" <?= !empty($settings['enable_shiprocket']) ? 'checked' : '' ?>> Enable Shiprocket</label><br>
+
+    <h3>Delhivery</h3>
+    <label for="delhivery_api_key">API Key:</label><br>
+    <input type="text" id="delhivery_api_key" name="delhivery_api_key" value="<?= htmlspecialchars($settings['delhivery_api_key'] ?? '') ?>"><br>
+    <label for="delhivery_api_secret">API Secret:</label><br>
+    <input type="text" id="delhivery_api_secret" name="delhivery_api_secret" value="<?= htmlspecialchars($settings['delhivery_api_secret'] ?? '') ?>"><br>
+    <label><input type="checkbox" name="enable_delhivery" <?= !empty($settings['enable_delhivery']) ? 'checked' : '' ?>> Enable Delhivery</label><br>
+
+    <h3>Ekart</h3>
+    <label for="ekart_api_key">API Key:</label><br>
+    <input type="text" id="ekart_api_key" name="ekart_api_key" value="<?= htmlspecialchars($settings['ekart_api_key'] ?? '') ?>"><br>
+    <label for="ekart_api_secret">API Secret:</label><br>
+    <input type="text" id="ekart_api_secret" name="ekart_api_secret" value="<?= htmlspecialchars($settings['ekart_api_secret'] ?? '') ?>"><br>
+    <label><input type="checkbox" name="enable_ekart" <?= !empty($settings['enable_ekart']) ? 'checked' : '' ?>> Enable Ekart</label><br>
+
+    <button type="submit" name="save_delivery_settings">Save Delivery Partner Settings</button>
+</form>
+
+
+<h1>Settings</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<form method="post">
+    <label for="site_name">Site Name:</label><br>
+    <input type="text" id="site_name" name="site_name" required value="<?= htmlspecialchars($settings['site_name'] ?? '') ?>"><br><br>
+    <label for="site_email">Site Email:</label><br>
+    <input type="email" id="site_email" name="site_email" required value="<?= htmlspecialchars($settings['site_email'] ?? '') ?>"><br><br>
+    <label for="store_password">Store Password (leave blank to keep current):</label><br>
+    <input type="password" id="store_password" name="store_password" autocomplete="new-password"><br><br>
+    <label for="store_password_enabled">
+        <input type="checkbox" id="store_password_enabled" name="store_password_enabled" value="1" <?= !empty($settings['store_password_enabled']) ? 'checked' : '' ?>>
+        Enable Store Password Protection
+    </label><br><br>
+
+    <h2>Pixel Integrations</h2>
+
+    <label for="enable_facebook_pixel">
+        <input type="checkbox" id="enable_facebook_pixel" name="enable_facebook_pixel" value="1" <?= !empty($settings['enable_facebook_pixel']) ? 'checked' : '' ?>>
+        Enable Facebook Pixel
+    </label><br>
+
+    <label for="facebook_pixel_id">Facebook Pixel ID:</label><br>
+    <input type="text" id="facebook_pixel_id" name="facebook_pixel_id" value="<?= htmlspecialchars($settings['facebook_pixel_id'] ?? '') ?>"><br><br>
+
+    <label for="enable_google_analytics">
+        <input type="checkbox" id="enable_google_analytics" name="enable_google_analytics" value="1" <?= !empty($settings['enable_google_analytics']) ? 'checked' : '' ?>>
+        Enable Google Analytics
+    </label><br>
+
+    <label for="google_analytics_id">Google Analytics Tracking ID:</label><br>
+    <input type="text" id="google_analytics_id" name="google_analytics_id" value="<?= htmlspecialchars($settings['google_analytics_id'] ?? '') ?>"><br><br>
+
+    <label for="enable_snapchat_pixel">
+        <input type="checkbox" id="enable_snapchat_pixel" name="enable_snapchat_pixel" value="1" <?= !empty($settings['enable_snapchat_pixel']) ? 'checked' : '' ?>>
+        Enable Snapchat Pixel
+    </label><br>
+
+    <label for="snapchat_pixel_id">Snapchat Pixel ID:</label><br>
+    <input type="text" id="snapchat_pixel_id" name="snapchat_pixel_id" value="<?= htmlspecialchars($settings['snapchat_pixel_id'] ?? '') ?>"><br><br>
+
+    <button type="submit">Update Settings</button>
+</form>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>

--- a/admin/themes/index.php
+++ b/admin/themes/index.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+$pageTitle = 'Themes Overview';
+require __DIR__ . '/../components/header.php';
+?>
+<h1>Themes</h1>
+<p>Theme management options.</p>
+<ul>
+  <li><a href="themes.php">Themes</a></li>
+  <li><a href="theme-editor.php" target="_blank">Theme Editor</a></li>
+  <li><a href="../editor/theme-settings.php">Theme Settings</a></li>
+</ul>
+<?php require __DIR__ . '/../components/footer.php'; ?>

--- a/admin/themes/theme-editor.php
+++ b/admin/themes/theme-editor.php
@@ -1,0 +1,1010 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Editor';
+
+// Load theme pages layout JSON and global settings from DB or fallback to defaults
+// For demo, load from JSON files or stub data
+
+$themeId = $_GET['theme_id'] ?? 1;
+$pageType = $_GET['page'] ?? 'index';
+
+// Load layout JSON for the page
+$templateSlug = $pageType;
+$layoutJsonPath = __DIR__ . "/../../themes/default/templates/{$templateSlug}.json";
+$layoutJson = file_exists($layoutJsonPath) ? file_get_contents($layoutJsonPath) : '[]';
+$layout = json_decode($layoutJson, true);
+
+// Load global theme settings
+$settingsJsonPath = __DIR__ . "/../../themes/default/config/settings_data.json";
+$settingsJson = file_exists($settingsJsonPath) ? file_get_contents($settingsJsonPath) : '{}';
+$settings = json_decode($settingsJson, true);
+
+// Load available sections from schema files
+$sectionsDir = __DIR__ . "/../../themes/default/sections";
+$sectionSchemas = [];
+foreach (glob($sectionsDir . "/*.schema.json") as $schemaFile) {
+    $schemaContent = file_get_contents($schemaFile);
+    $schema = json_decode($schemaContent, true);
+    if ($schema && isset($schema['name'])) {
+        $sectionSchemas[basename($schemaFile, '.schema.json')] = $schema;
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Theme Editor - Pages Tab</title>
+<link rel="stylesheet" href="/admin/assets/theme-editor.css" />
+</head>
+<body class="theme-editor">
+  <div class="editor-header">
+    <h1>Theme Editor</h1>
+    <div class="header-actions">
+      <select id="page-select" aria-label="Select page to edit">
+        <option value="">-- Select Page --</option>
+      </select>
+      <button id="save-layout-btn">Save Changes</button>
+      <div class="device-toggle">
+        <button type="button" data-width="100%" class="active" id="device-desktop">Desktop</button>
+        <button type="button" data-width="768px" id="device-tablet">Tablet</button>
+        <button type="button" data-width="375px" id="device-mobile">Mobile</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Section Modal -->
+  <div id="add-section-modal" class="modal">
+    <div class="modal-content">
+      <button type="button" class="close-modal" aria-label="Close">&times;</button>
+      <input type="text" id="section-search" placeholder="Search sections" />
+      <div id="section-card-list">
+        <?php foreach ($sectionSchemas as $key => $schema): ?>
+          <div class="section-card" data-type="<?php echo htmlspecialchars($key); ?>">
+            <img src="/themes/default/sections/<?php echo htmlspecialchars($key); ?>.png" alt="" onerror="this.style.display='none'" />
+            <h4><?php echo htmlspecialchars($schema['name']); ?></h4>
+          </div>
+        <?php endforeach; ?>
+      </div>
+    </div>
+  </div>
+  <div class="container">
+    <div class="sidebar">
+      <h2>Page Sections (<span id="page-type-label"><?php echo htmlspecialchars($pageType); ?></span>)</h2>
+      <div class="sidebar-search">
+        <input type="text" id="section-filter" placeholder="Search sections and blocks..." />
+      </div>
+      <div id="section-list" aria-live="polite" aria-relevant="additions removals">
+        <!-- Sections will be loaded here -->
+      </div>
+      <div class="add-section">
+        <button id="open-add-section" data-group="template">Add Section</button>
+      </div>
+      <div id="version-history">
+        <h3>Version History</h3>
+        <ul id="version-list"></ul>
+      </div>
+    </div>
+    <div class="content">
+      <h2>Live Preview</h2>
+      <iframe id="preview-frame" src="/?preview_theme_id=<?php echo $themeId; ?>&page=<?php echo htmlspecialchars($pageType); ?>"></iframe>
+    </div>
+  </div>
+
+<script>
+    let selectedSectionIndex = null;
+    let layoutDirty = false;
+  const pageSelect = document.getElementById('page-select');
+  const pageTypeLabel = document.getElementById('page-type-label');
+  const sectionList = document.getElementById('section-list');
+  const openAddBtn = document.getElementById('open-add-section');
+  const modal = document.getElementById('add-section-modal');
+  const sectionSearch = document.getElementById('section-search');
+  const searchInput = document.getElementById('section-filter');
+  const previewFrame = document.getElementById('preview-frame');
+  const deviceButtons = document.querySelectorAll('.device-toggle button');
+
+  let addTargetGroup = 'template';
+
+  let currentLayout = [];
+  let currentPage = '<?php echo htmlspecialchars($pageType); ?>';
+
+  // Load pages for page selector
+  async function loadPages() {
+    const response = await fetch('/admin/api/get-pages.php');
+    if (!response.ok) return;
+    const pages = await response.json();
+    pageSelect.innerHTML = '<option value="">-- Select Page --</option>';
+    pages.forEach(page => {
+      const option = document.createElement('option');
+      option.value = page;
+      option.textContent = (page === 'index') ? 'Home' : (page.charAt(0).toUpperCase() + page.slice(1));
+      if (page === currentPage) option.selected = true;
+      pageSelect.appendChild(option);
+    });
+  }
+
+  // Load layout for selected page
+  async function loadLayout(page) {
+    if (!page) return;
+    
+let fileSlug = page;
+
+    const response = await fetch(`/admin/api/get-page-layout.php?page=${fileSlug}`);
+    if (!response.ok) {
+      alert('Failed to load page layout');
+      return;
+    }
+    const layout = await response.json();
+    console.log('Loaded layout:', layout);
+    if (!layout || layout.error) {
+      alert(layout?.error || 'Invalid layout format received');
+      currentLayout = [];
+    } else if (Array.isArray(layout.sections)) {
+      currentLayout = layout.sections;
+    } else if (layout.sections && typeof layout.sections === 'object' && Array.isArray(layout.order)) {
+      // Convert old format to array
+      currentLayout = layout.order.map(key => layout.sections[key]).filter(Boolean);
+    } else {
+      alert('Invalid layout format received');
+      currentLayout = [];
+    }
+    currentPage = page; // Move this before updatePreview
+    pageTypeLabel.textContent = page.charAt(0).toUpperCase() + page.slice(1);
+    renderSections();
+    updatePreview();
+  }
+
+  // Categorize sections into groups
+  function categorizeSections() {
+    const groups = { header: [], template: [], footer: [] };
+    currentLayout.forEach((sec, idx) => {
+      if (sec.type.includes('header') || sec.type.includes('announcement')) {
+        groups.header.push({ section: sec, index: idx });
+      } else if (sec.type.includes('footer')) {
+        groups.footer.push({ section: sec, index: idx });
+      } else {
+        groups.template.push({ section: sec, index: idx });
+      }
+    });
+    return groups;
+  }
+
+  // Build single list item
+  function buildSectionItem(section, index) {
+    const li = document.createElement('li');
+    li.className = 'section-item';
+    if (selectedSectionIndex === index) li.classList.add('active');
+    li.draggable = true;
+    li.dataset.index = index;
+
+    const handle = document.createElement('span');
+    handle.textContent = '\u2837';
+    handle.className = 'drag-handle';
+    li.appendChild(handle);
+
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = section.type;
+    li.appendChild(nameSpan);
+
+    const actions = document.createElement('span');
+    actions.className = 'actions';
+
+    const dupBtn = document.createElement('button');
+    dupBtn.textContent = '⧉';
+    dupBtn.title = 'Duplicate';
+    dupBtn.addEventListener('click', e => { e.stopPropagation(); duplicateSection(index); });
+    actions.appendChild(dupBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.textContent = '🗑';
+    delBtn.title = 'Delete';
+    delBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      if (confirm('Are you sure you want to delete this section?')) deleteSection(index);
+    });
+    actions.appendChild(delBtn);
+
+    const codeBtn = document.createElement('button');
+    codeBtn.textContent = '</>';
+    codeBtn.title = 'Edit code';
+    codeBtn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const res = await fetch(`/admin/api/get-section-code.php?section=${section.type}`);
+      if (!res.ok) return alert('Failed to load code');
+      const data = await res.json();
+      const updated = prompt('Edit code for ' + section.type, data.code);
+      if (updated !== null) {
+        await fetch('/admin/api/save-section-code.php', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ section: section.type, code: updated }) });
+      }
+    });
+    actions.appendChild(codeBtn);
+
+    li.appendChild(actions);
+
+    if (Array.isArray(section.blocks) && section.blocks.length) {
+      const bUl = document.createElement('ul');
+      bUl.className = 'block-list';
+      section.blocks.forEach(b => {
+        const bi = document.createElement('li');
+        bi.className = 'block-item';
+        bi.textContent = b.type;
+        bUl.appendChild(bi);
+      });
+      li.appendChild(bUl);
+    }
+
+    li.addEventListener('click', () => {
+      sectionList.style.display = 'none';
+      document.querySelector('.add-section').style.display = 'none';
+      selectedSectionIndex = index;
+      renderSections();
+      showCustomizer(index);
+    });
+
+    return li;
+  }
+
+  function showCustomizer(index) {
+    let customizer = document.getElementById('section-customizer');
+    if (!customizer) {
+      customizer = document.createElement('div');
+      customizer.id = 'section-customizer';
+      customizer.style.flexGrow = '1';
+      customizer.style.display = 'block';
+      customizer.style.padding = '10px';
+      customizer.style.borderTop = '1px solid #ccc';
+      customizer.style.overflowY = 'auto';
+      customizer.style.flexBasis = '100%';
+      document.querySelector('.sidebar').appendChild(customizer);
+    } else {
+      customizer.style.display = 'block';
+    }
+
+    let backBtn = document.getElementById('back-to-sections-btn');
+    if (!backBtn) {
+      backBtn = document.createElement('button');
+      backBtn.id = 'back-to-sections-btn';
+      backBtn.textContent = 'Back to Sections';
+      backBtn.style.marginBottom = '10px';
+      backBtn.style.fontWeight = 'bold';
+      backBtn.addEventListener('click', () => {
+        sectionList.style.display = 'block';
+        document.querySelector('.add-section').style.display = 'block';
+        customizer.style.display = 'none';
+        const form = document.getElementById('customizer-form');
+        if (form) form.innerHTML = '';
+        selectedSectionIndex = null;
+        backBtn.remove();
+        renderSections();
+      });
+      customizer.insertBefore(backBtn, customizer.firstChild);
+    }
+
+    openCustomizerForSection(index);
+  }
+
+  function renderSections() {
+    sectionList.innerHTML = '';
+    const groups = categorizeSections();
+    const filter = (searchInput.value || '').toLowerCase();
+    ['header','template','footer'].forEach(g => {
+      const arr = groups[g];
+      const wrapper = document.createElement('div');
+      wrapper.className = 'section-group';
+      const header = document.createElement('div');
+      header.className = 'section-group-header';
+      header.innerHTML = `<span>${g.toUpperCase()}</span><span class="chevron">▾</span>`;
+      header.addEventListener('click', () => wrapper.classList.toggle('collapsed'));
+      wrapper.appendChild(header);
+      const ul = document.createElement('ul');
+      ul.className = 'section-group-list';
+      arr.forEach(item => {
+        if (filter && !item.section.type.toLowerCase().includes(filter)) return;
+        ul.appendChild(buildSectionItem(item.section, item.index));
+      });
+      wrapper.appendChild(ul);
+      const addBtn = document.createElement('button');
+      addBtn.className = 'add-section-inline';
+      addBtn.textContent = `+ Add section under ${g.charAt(0).toUpperCase()+g.slice(1)}`;
+      addBtn.addEventListener('click', () => {
+        addTargetGroup = g;
+        modal.style.display = 'flex';
+        sectionSearch.value = '';
+        filterCards('');
+      });
+      wrapper.appendChild(addBtn);
+      sectionList.appendChild(wrapper);
+    });
+    addDragAndDropHandlers();
+  }
+
+  // Duplicate section function
+  function duplicateSection(index) {
+    if (index < 0 || index >= currentLayout.length) return;
+    const sectionToDuplicate = currentLayout[index];
+    const newId = `${sectionToDuplicate.type}-${Date.now()}`;
+    const duplicatedSection = JSON.parse(JSON.stringify(sectionToDuplicate));
+    duplicatedSection.id = newId;
+    currentLayout.splice(index + 1, 0, duplicatedSection);
+    renderSections();
+    layoutDirty = true;
+    updatePreview();
+  }
+
+  // Delete section function
+  function deleteSection(index) {
+    if (index < 0 || index >= currentLayout.length) return;
+    currentLayout.splice(index, 1);
+    renderSections();
+    layoutDirty = true;
+    updatePreview();
+  }
+  // Open customization panel for a section
+  async function openCustomizerForSection(index) {
+    selectedSectionIndex = index;
+    const section = currentLayout[index];
+    if (!section) return;
+    let form = document.getElementById("customizer-form");
+    let customizer = document.getElementById('section-customizer');
+    if (!customizer) {
+      customizer = document.createElement('div');
+      customizer.id = 'section-customizer';
+      customizer.style.flexGrow = '1';
+      customizer.style.display = 'block';
+      customizer.style.padding = '10px';
+      customizer.style.borderTop = '1px solid #ccc';
+      customizer.style.overflowY = 'auto';
+      customizer.style.flexBasis = '100%';
+      document.querySelector('.sidebar').appendChild(customizer);
+    }
+    if (!form) {
+      form = document.createElement("form");
+      form.id = "customizer-form";
+      form.style.display = "flex";
+      form.style.flexDirection = "column";
+      form.style.gap = "10px";
+      customizer.appendChild(form);
+    }
+    form.innerHTML = "";
+    const response = await fetch(`/admin/api/get-section-schema.php?section=${section.type}`);
+    if (!response.ok) {
+      form.innerHTML = "<p>Failed to load section schema.</p>";
+      return;
+    }
+    const schema = await response.json();
+    if (!schema || !schema.settings) {
+      form.innerHTML = "<p>No customization available.</p>";
+      return;
+    }
+    schema.settings.forEach(setting => {
+      const wrapper = document.createElement("div");
+      wrapper.style.marginBottom = "10px";
+      const label = document.createElement("label");
+      label.textContent = setting.label || setting.id;
+      label.htmlFor = setting.id;
+      wrapper.appendChild(label);
+      let input;
+      switch (setting.type) {
+        case "textarea":
+          input = document.createElement("textarea");
+          break;
+        case "select":
+          input = document.createElement("select");
+          (setting.options || []).forEach(opt => {
+            const optEl = document.createElement("option");
+            optEl.value = opt.value;
+            optEl.textContent = opt.label;
+            if (section.settings[setting.id] === opt.value) optEl.selected = true;
+            input.appendChild(optEl);
+          });
+          break;
+        case "image":
+          input = document.createElement("input");
+          input.type = "file";
+          input.accept = "image/*";
+          let preview = null;
+          if (section.settings[setting.id]) {
+            preview = document.createElement('img');
+            preview.src = section.settings[setting.id];
+            preview.style.maxWidth = '100%';
+            wrapper.appendChild(preview);
+          }
+          input.addEventListener('change', async () => {
+            if (!input.files.length) return;
+            const fd = new FormData();
+            fd.append('image', input.files[0]);
+            try {
+              const r = await fetch('/backend/themes/upload-image.php', { method: 'POST', body: fd });
+              const d = await r.json();
+              if (d.success) {
+                section.settings[setting.id] = '/uploads/themes/images/' + d.filename;
+                if (!preview) {
+                  preview = document.createElement('img');
+                  preview.style.maxWidth = '100%';
+                  wrapper.insertBefore(preview, input);
+                }
+                preview.src = section.settings[setting.id];
+                layoutDirty = true;
+                updatePreview();
+              } else {
+                alert(d.error || 'Upload failed');
+              }
+            } catch (e) {
+              console.error('Image upload failed', e);
+              alert('Image upload failed');
+            }
+          });
+          break;
+        case "collection_select":
+          input = document.createElement("select");
+          input.innerHTML = '<option value="">Loading...</option>';
+          fetch('/admin/api/get-collections.php')
+            .then(r => r.json())
+            .then(d => {
+              input.innerHTML = '<option value="">-- Select Collection --</option>';
+              if (d.success) {
+                d.collections.forEach(c => {
+                  const opt = document.createElement('option');
+                  opt.value = c.id;
+                  opt.textContent = c.title || c.name;
+                  if (section.settings[setting.id] == c.id) opt.selected = true;
+                  input.appendChild(opt);
+                });
+              }
+            });
+          break;
+        case "product_select":
+        case "product":
+          input = document.createElement("select");
+          input.innerHTML = '<option value="">Loading...</option>';
+          fetch('/admin/api/get-products.php')
+            .then(r => r.json())
+            .then(d => {
+              input.innerHTML = '<option value="">-- Select Product --</option>';
+              if (d.success) {
+                d.products.forEach(p => {
+                  const opt = document.createElement('option');
+                  opt.value = p.id;
+                  opt.textContent = p.title;
+                  if (section.settings[setting.id] == p.id) opt.selected = true;
+                  input.appendChild(opt);
+                });
+              }
+            });
+          break;
+        case "product_set_select":
+          input = document.createElement("select");
+          input.innerHTML = '<option value="">Loading...</option>';
+          fetch('/admin/api/get-product-sets.php')
+            .then(r => r.json())
+            .then(d => {
+              input.innerHTML = '<option value="">-- Select Set --</option>';
+              if (d.success) {
+                d.sets.forEach(s => {
+                  const opt = document.createElement('option');
+                  opt.value = s.id;
+                  opt.textContent = s.title;
+                  if (section.settings[setting.id] == s.id) opt.selected = true;
+                  input.appendChild(opt);
+                });
+              }
+            });
+          break;
+        case "checkbox":
+          input = document.createElement("input");
+          input.type = "checkbox";
+          input.checked = !!section.settings[setting.id];
+          break;
+        default:
+          input = document.createElement("input");
+          input.type = setting.type || "text";
+          input.value = section.settings[setting.id] || "";
+      }
+      input.id = setting.id;
+      input.name = setting.id;
+      const onChange = () => {
+        if (setting.type === "checkbox") {
+          section.settings[setting.id] = input.checked;
+        } else {
+          section.settings[setting.id] = input.value;
+        }
+        layoutDirty = true;
+        updatePreview();
+      };
+      input.addEventListener("input", onChange);
+      input.addEventListener("change", onChange);
+      wrapper.appendChild(input);
+      form.appendChild(wrapper);
+    });
+
+    // Add style presets selector
+    const stylePresets = ['default', 'light', 'dark', 'full-width'];
+    const presetWrapper = document.createElement("div");
+    presetWrapper.style.marginBottom = "10px";
+    const presetLabel = document.createElement("label");
+    presetLabel.textContent = "Style Preset";
+    presetLabel.htmlFor = "style-preset-select";
+    presetWrapper.appendChild(presetLabel);
+
+    const presetSelect = document.createElement("select");
+    presetSelect.id = "style-preset-select";
+    presetSelect.name = "style-preset-select";
+
+    stylePresets.forEach(preset => {
+      const option = document.createElement("option");
+      option.value = preset;
+      option.textContent = preset.charAt(0).toUpperCase() + preset.slice(1);
+      if (section.settings.stylePreset === preset) option.selected = true;
+      presetSelect.appendChild(option);
+    });
+
+    presetSelect.addEventListener("change", () => {
+      section.settings.stylePreset = presetSelect.value;
+      layoutDirty = true;
+      updatePreview();
+    });
+
+    presetWrapper.appendChild(presetSelect);
+    form.appendChild(presetWrapper);
+
+    // Add device visibility toggles
+    const visibilityWrapper = document.createElement("div");
+    visibilityWrapper.style.marginBottom = "10px";
+
+    const visibilityLabel = document.createElement("label");
+    visibilityLabel.textContent = "Visibility";
+    visibilityWrapper.appendChild(visibilityLabel);
+
+    const mobileCheckbox = document.createElement("input");
+    mobileCheckbox.type = "checkbox";
+    mobileCheckbox.id = "visibility-mobile";
+    mobileCheckbox.name = "visibility-mobile";
+    mobileCheckbox.checked = section.settings.visibility?.mobile !== false; // default true
+    const mobileLabel = document.createElement("label");
+    mobileLabel.htmlFor = "visibility-mobile";
+    mobileLabel.textContent = "Show on Mobile";
+
+    const desktopCheckbox = document.createElement("input");
+    desktopCheckbox.type = "checkbox";
+    desktopCheckbox.id = "visibility-desktop";
+    desktopCheckbox.name = "visibility-desktop";
+    desktopCheckbox.checked = section.settings.visibility?.desktop !== false; // default true
+    const desktopLabel = document.createElement("label");
+    desktopLabel.htmlFor = "visibility-desktop";
+    desktopLabel.textContent = "Show on Desktop";
+
+    mobileCheckbox.addEventListener("change", () => {
+      if (!section.settings.visibility) section.settings.visibility = {};
+      section.settings.visibility.mobile = mobileCheckbox.checked;
+      layoutDirty = true;
+      updatePreview();
+    });
+
+    desktopCheckbox.addEventListener("change", () => {
+      if (!section.settings.visibility) section.settings.visibility = {};
+      section.settings.visibility.desktop = desktopCheckbox.checked;
+      layoutDirty = true;
+      updatePreview();
+    });
+
+    visibilityWrapper.appendChild(mobileCheckbox);
+    visibilityWrapper.appendChild(mobileLabel);
+    visibilityWrapper.appendChild(document.createElement("br"));
+    visibilityWrapper.appendChild(desktopCheckbox);
+    visibilityWrapper.appendChild(desktopLabel);
+
+    form.appendChild(visibilityWrapper);
+
+    // ----- Blocks Management -----
+    if (Array.isArray(schema.blocks) && schema.blocks.length) {
+      const blocksWrapper = document.createElement('div');
+      blocksWrapper.style.marginTop = '10px';
+
+      const blocksHeader = document.createElement('h3');
+      blocksHeader.textContent = 'Blocks';
+      blocksWrapper.appendChild(blocksHeader);
+
+      const blockList = document.createElement('div');
+      blocksWrapper.appendChild(blockList);
+
+      function renderBlocks() {
+        blockList.innerHTML = '';
+        (section.blocks || []).forEach((block, bIndex) => {
+          const blockDiv = document.createElement('div');
+          blockDiv.style.border = '1px solid #ccc';
+          blockDiv.style.padding = '5px';
+          blockDiv.style.marginBottom = '5px';
+
+          const title = document.createElement('strong');
+          title.textContent = block.type;
+          blockDiv.appendChild(title);
+
+          const del = document.createElement('button');
+          del.textContent = 'Delete';
+          del.style.marginLeft = '10px';
+          del.addEventListener('click', () => {
+            section.blocks.splice(bIndex, 1);
+            layoutDirty = true;
+            renderBlocks();
+            updatePreview();
+          });
+          blockDiv.appendChild(del);
+
+          const bSchema = schema.blocks.find(b => b.type === block.type) || {settings:[]};
+          (bSchema.settings || []).forEach(bs => {
+            const lbl = document.createElement('label');
+            lbl.textContent = bs.label || bs.id;
+            lbl.style.display = 'block';
+            let inp;
+            if (bs.type === 'textarea') {
+              inp = document.createElement('textarea');
+              inp.value = block.settings[bs.id] || '';
+              inp.addEventListener('input', () => {
+                block.settings[bs.id] = inp.value;
+                layoutDirty = true;
+                updatePreview();
+              });
+              blockDiv.appendChild(lbl);
+              blockDiv.appendChild(inp);
+              return;
+            }
+
+            if (bs.type === 'image') {
+              inp = document.createElement('input');
+              inp.type = 'file';
+              inp.accept = 'image/*';
+              let imgPrev = null;
+              if (block.settings[bs.id]) {
+                imgPrev = document.createElement('img');
+                imgPrev.src = block.settings[bs.id];
+                imgPrev.style.maxWidth = '100%';
+                blockDiv.appendChild(imgPrev);
+              }
+              inp.addEventListener('change', async () => {
+                if (!inp.files.length) return;
+                const fd = new FormData();
+                fd.append('image', inp.files[0]);
+                try {
+                  const res = await fetch('/backend/themes/upload-image.php', { method: 'POST', body: fd });
+                  const data = await res.json();
+                  if (data.success) {
+                    block.settings[bs.id] = '/uploads/themes/images/' + data.filename;
+                    if (!imgPrev) {
+                      imgPrev = document.createElement('img');
+                      imgPrev.style.maxWidth = '100%';
+                      blockDiv.insertBefore(imgPrev, inp);
+                    }
+                    imgPrev.src = block.settings[bs.id];
+                    layoutDirty = true;
+                    updatePreview();
+                  } else {
+                    alert(data.error || 'Upload failed');
+                  }
+                } catch (e) {
+                  console.error('Image upload failed', e);
+                  alert('Image upload failed');
+                }
+              });
+            } else {
+              inp = document.createElement('input');
+              inp.type = bs.type || 'text';
+              inp.value = block.settings[bs.id] || '';
+              inp.addEventListener('input', () => {
+                block.settings[bs.id] = inp.value;
+                layoutDirty = true;
+                updatePreview();
+              });
+            }
+            blockDiv.appendChild(lbl);
+            blockDiv.appendChild(inp);
+          });
+
+          blockList.appendChild(blockDiv);
+        });
+      }
+
+      const addSelect = document.createElement('select');
+      const blank = document.createElement('option');
+      blank.value = '';
+      blank.textContent = '-- Add Block --';
+      addSelect.appendChild(blank);
+      schema.blocks.forEach(b => {
+        const opt = document.createElement('option');
+        opt.value = b.type;
+        opt.textContent = b.name || b.type;
+        addSelect.appendChild(opt);
+      });
+
+      const addBtn = document.createElement('button');
+      addBtn.textContent = 'Add';
+      addBtn.addEventListener('click', () => {
+        const type = addSelect.value;
+        if (!type) return;
+        const bSchema = schema.blocks.find(b => b.type === type) || {settings:[]};
+        const settings = {};
+        (bSchema.settings || []).forEach(s => { settings[s.id] = s.default ?? ''; });
+        if (!Array.isArray(section.blocks)) section.blocks = [];
+        section.blocks.push({type, settings});
+        addSelect.value = '';
+        layoutDirty = true;
+        renderBlocks();
+        updatePreview();
+      });
+
+      blocksWrapper.appendChild(addSelect);
+      blocksWrapper.appendChild(addBtn);
+
+      form.appendChild(blocksWrapper);
+      renderBlocks();
+    }
+
+  }
+
+  // Save button click handler
+  document.getElementById('save-layout-btn').addEventListener('click', async () => {
+    if (!layoutDirty) {
+      alert('No changes to save.');
+      return;
+    }
+
+    try {
+      await saveLayout();
+      alert('Layout and section settings saved successfully!');
+      layoutDirty = false;
+      updatePreview();
+
+      // Save version after successful save
+      await saveLayoutVersion();
+
+    } catch (error) {
+      console.error('Error while saving:', error);
+      alert('Something went wrong while saving. Please try again.');
+    }
+  });
+
+  // Auto-save draft every 30 seconds if layout is dirty
+  setInterval(() => {
+    if (layoutDirty) {
+      saveLayoutVersion(true);
+    }
+  }, 30000);
+
+  // Save layout version function
+  async function saveLayoutVersion(isAutoSave = false) {
+    const layoutObj = { sections: {}, order: [] };
+    currentLayout.forEach(sec => {
+      const id = sec.id || `${sec.type}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+      sec.id = id;
+      layoutObj.sections[id] = { type: sec.type, settings: sec.settings || {}, blocks: sec.blocks || [] };
+      layoutObj.order.push(id);
+    });
+
+    const payload = { page: currentPage, layout: layoutObj };
+
+    if (!isAutoSave) {
+      // Prompt user for version label
+      const label = prompt('Enter version label (optional):');
+      if (label) {
+        payload.version = label.replace(/[^a-zA-Z0-9-_]/g, '_');
+      }
+    } else {
+      // Auto-save version with timestamp
+      payload.version = new Date().toISOString().replace(/[-:.TZ]/g, '');
+    }
+
+    try {
+      let response = await fetch('/admin/api/save-layout-version.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      let result = await response.json();
+      if (!result.success) throw new Error(result.error || 'Failed to save layout version');
+      if (!isAutoSave) alert('Layout version saved: ' + (payload.version || result.version));
+    } catch (error) {
+      console.error('Failed to save layout version:', error);
+      if (!isAutoSave) alert('Failed to save layout version. Please try again.');
+    }
+  }
+
+  // Add drag and drop handlers
+  function addDragAndDropHandlers() {
+    let dragSrcEl = null;
+
+    function handleDragStart(e) {
+      dragSrcEl = this;
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', this.dataset.index);
+      this.style.opacity = '0.4';
+    }
+
+    function handleDragOver(e) {
+      if (e.preventDefault) e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      return false;
+    }
+
+    function handleDrop(e) {
+      if (e.stopPropagation) e.stopPropagation();
+      const srcIndex = parseInt(e.dataTransfer.getData('text/plain'), 10);
+      const targetIndex = parseInt(this.dataset.index, 10);
+      if (srcIndex !== targetIndex) {
+        const moved = currentLayout.splice(srcIndex, 1)[0];
+        currentLayout.splice(targetIndex, 0, moved);
+        renderSections();
+        layoutDirty = true;
+        updatePreview();
+      }
+      return false;
+    }
+
+    function handleDragEnd(e) {
+      this.style.opacity = '1';
+    }
+
+    const items = document.querySelectorAll('.section-item');
+    items.forEach(item => {
+      item.addEventListener('dragstart', handleDragStart, false);
+      item.addEventListener('dragover', handleDragOver, false);
+      item.addEventListener('drop', handleDrop, false);
+      item.addEventListener('dragend', handleDragEnd, false);
+    });
+  }
+
+
+  function addSectionOfType(sectionType, group) {
+    fetch(`/admin/api/get-section-schema.php?section=${sectionType}`)
+      .then(r => r.json())
+      .then(schema => {
+        const uniqueId = `${sectionType}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+        const presetSettings = schema?.presets?.default?.settings || {};
+        const defaultSettings = {};
+        (schema.settings || []).forEach(s => { defaultSettings[s.id] = presetSettings[s.id] ?? s.default ?? '' });
+        const blocks = (schema.blocks || []).map(b => {
+          const bs = {}; (b.settings||[]).forEach(s=>{bs[s.id]=s.default??''});
+          return {type:b.type, settings: bs};
+        });
+        let insertIndex = currentLayout.length;
+        if (group === 'header') {
+          insertIndex = currentLayout.findIndex(s => !(s.type.includes('header') || s.type.includes('announcement')));
+          if (insertIndex === -1) insertIndex = 0;
+        } else if (group === 'template') {
+          insertIndex = currentLayout.findIndex(s => s.type.includes('footer'));
+          if (insertIndex === -1) insertIndex = currentLayout.length;
+        }
+        const newSec = { id: uniqueId, type: sectionType, settings: defaultSettings, blocks };
+        currentLayout.splice(insertIndex, 0, newSec);
+        renderSections(); layoutDirty = true; updatePreview();
+      }).catch(err => {
+        console.error('Failed adding section', err);
+        alert('Could not add section');
+      });
+  }
+
+  openAddBtn.addEventListener('click', () => {
+    addTargetGroup = openAddBtn.dataset.group || 'template';
+    modal.style.display = 'flex';
+    sectionSearch.value = '';
+    filterCards('');
+  });
+
+  document.querySelector('#add-section-modal .close-modal').addEventListener('click', () => {
+    modal.style.display = 'none';
+  });
+
+  function filterCards(q) {
+    document.querySelectorAll('#section-card-list .section-card').forEach(card => {
+      card.style.display = card.querySelector('h4').textContent.toLowerCase().includes(q.toLowerCase()) ? 'flex' : 'none';
+    });
+  }
+  sectionSearch.addEventListener('input', e => filterCards(e.target.value));
+  searchInput.addEventListener('input', renderSections);
+
+  document.querySelectorAll('#section-card-list .section-card').forEach(card => {
+    card.addEventListener('click', () => {
+      modal.style.display = 'none';
+      addSectionOfType(card.dataset.type, addTargetGroup);
+    });
+  });
+
+
+// Update live preview iframe with session layout override
+function updatePreview() {
+  // Send current layout to session for preview rendering
+  fetch('/admin/api/set-live-preview.php', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      page: currentPage,
+      layout: currentLayout
+    })
+  }).then(() => {
+    // After storing in session, reload preview iframe
+    const livePage = currentPage;
+    previewFrame.src = `/?preview=1&page=${livePage}&t=${Date.now()}`;
+  }).catch((err) => {
+    console.error('Failed to update preview:', err);
+    alert('Preview update failed.');
+  });
+}
+
+// Page selector change handler
+pageSelect.addEventListener('change', () => {
+  const selectedPage = pageSelect.value;
+  if (selectedPage) {
+    loadLayout(selectedPage).then(() => {
+      updatePreview(); // ✅ force reload preview
+    });
+  }
+});
+
+// Initial load
+loadPages().then(() => {
+  pageSelect.value = currentPage;
+  pageSelect.dispatchEvent(new Event('change'));
+});
+
+  deviceButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      deviceButtons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      previewFrame.style.width = btn.dataset.width;
+    });
+  });
+
+
+  // Define the missing saveLayout function
+async function saveLayout() {
+  const layoutObj = { sections: {}, order: [] };
+
+  currentLayout.forEach(sec => {
+    const id = sec.id || `${sec.type}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    sec.id = id; // Ensure ID is assigned and consistent
+    layoutObj.sections[id] = {
+      type: sec.type,
+      settings: sec.settings || {},
+      blocks: sec.blocks || []
+    };
+    layoutObj.order.push(id);
+  });
+
+  const payload = {
+    page: currentPage,
+    layout: layoutObj
+  };
+
+  try {
+    const response = await fetch('/admin/api/save-layout.php', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    const result = await response.json();
+    if (!result.success) throw new Error(result.error || 'Failed to save layout');
+
+    layoutDirty = false;
+    console.log('Layout saved successfully!');
+  } catch (err) {
+    console.error('Error saving layout:', err);
+    alert('Failed to save layout. Please try again.');
+  }
+}
+
+
+</script>
+</body>
+</html>

--- a/admin/themes/theme-editor.php
+++ b/admin/themes/theme-editor.php
@@ -318,7 +318,8 @@ let fileSlug = page;
       wrapper.appendChild(ul);
       const addBtn = document.createElement('button');
       addBtn.className = 'add-section-inline';
-      addBtn.textContent = `+ Add section under ${g.charAt(0).toUpperCase()+g.slice(1)}`;
+      addBtn.textContent = '';
+      addBtn.setAttribute('aria-label', `Add section under ${g.charAt(0).toUpperCase()+g.slice(1)}`);
       addBtn.addEventListener('click', () => {
         addTargetGroup = g;
         modal.style.display = 'flex';

--- a/admin/themes/themes.php
+++ b/admin/themes/themes.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+session_start();
+require_once __DIR__ . '/../../db.php';
+require_once __DIR__ . '/../../functions.php';
+
+
+// Check if user is logged in
+if (!isset($_SESSION['user_id'])) {
+    header('Location: /backend/auth/login.php');
+    exit;
+}
+
+$pageTitle = 'Themes';
+
+// Handle form submissions for activating or deleting themes
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    $themeId = $_POST['theme_id'] ?? null;
+
+    if ($action === 'activate' && $themeId) {
+        // Deactivate all themes
+        db_query('UPDATE themes SET active = 0');
+        // Activate selected theme
+        db_query('UPDATE themes SET active = 1 WHERE id = :id', [':id' => $themeId]);
+        $_SESSION['flash_message'] = 'Theme activated successfully.';
+    } elseif ($action === 'delete' && $themeId) {
+        db_query('DELETE FROM themes WHERE id = :id', [':id' => $themeId]);
+        $_SESSION['flash_message'] = 'Theme deleted successfully.';
+    }
+    header('Location: /admin/themes.php');
+    exit;
+}
+
+// Fetch all themes
+$themes = db_query('SELECT id, name, created_at FROM themes ORDER BY created_at DESC')->fetchAll();
+
+foreach ($themes as &$theme) {
+    if (!isset($theme['active'])) {
+        $theme['active'] = 0; // Set default value if 'active' is not set
+    }
+}
+unset($theme); // Unset the reference
+
+require __DIR__ . '/../components/header.php';
+?>
+
+<h1>Themes</h1>
+
+<?php if (!empty($_SESSION['flash_message'])): ?>
+    <div class="flash-message"><?= htmlspecialchars($_SESSION['flash_message']) ?></div>
+    <?php unset($_SESSION['flash_message']); ?>
+<?php endif; ?>
+
+<!-- Themes list -->
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Created At</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($themes as $theme): ?>
+        <tr>
+            <td><?= htmlspecialchars($theme['name']) ?></td>
+            <td><?= htmlspecialchars($theme['created_at']) ?></td>
+            <td>
+                <form method="post" style="display:inline;">
+                    <input type="hidden" name="action" value="activate">
+                    <input type="hidden" name="theme_id" value="<?= $theme['id'] ?>">
+                    <button type="submit">Activate</button>
+                </form>
+                <form method="post" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this theme?');">
+                    <input type="hidden" name="action" value="delete">
+                    <input type="hidden" name="theme_id" value="<?= $theme['id'] ?>">
+                    <button type="submit">Delete</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+    </tbody>
+</table>
+
+<?php
+require __DIR__ . '/../components/footer.php';
+?>


### PR DESCRIPTION
## Summary
- enhance admin navigation with clickable parents
- add nav toggle logic and active state highlighting
- style nav anchors
- create overview pages for each nav item
- include full admin functionality pages from archive

## Testing
- `php -l admin/components/nav.php`
- `php -l admin/activity/index.php`
- `php -l admin/products/index.php`
- `php -l admin/plugins/plugins.php`


------
https://chatgpt.com/codex/tasks/task_e_6873eec55c588328a6fe3e4e166f86a4